### PR TITLE
forSingleRole sync: lift SourceT bound

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
@@ -38,7 +38,7 @@ import jetbrains.jetpad.projectional.generic.Role;
 
 import java.util.List;
 
-class ProjectionalPropertySynchronizer<ContextT, SourceItemT extends ContextT> extends BaseProjectionalSynchronizer<Property<SourceItemT>, ContextT, SourceItemT> {
+class ProjectionalPropertySynchronizer<ContextT, SourceItemT> extends BaseProjectionalSynchronizer<Property<SourceItemT>, ContextT, SourceItemT> {
   private Property<SourceItemT> mySource;
 
   ProjectionalPropertySynchronizer(

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalSynchronizers.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalSynchronizers.java
@@ -56,7 +56,7 @@ public class ProjectionalSynchronizers {
     return new ProjectionalObservableListSynchronizer<>(mapper, source, target, targetList, factory);
   }
 
-  public static <ContextT, SourceT extends ContextT> ProjectionalRoleSynchronizer<ContextT, SourceT> forSingleRole(
+  public static <ContextT, SourceT> ProjectionalRoleSynchronizer<ContextT, SourceT> forSingleRole(
       Mapper<? extends ContextT, ? extends Cell> mapper,
       Property<SourceT> source, Cell target, MapperFactory<SourceT, Cell> factory) {
     return new ProjectionalPropertySynchronizer<>(mapper, source, target, factory);


### PR DESCRIPTION
My guess is that it is there for some historical reasons as I can’t see any use of it.