### PR TITLE
hybrid: Replace empty tokens with errors

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -19,7 +19,6 @@ import com.google.common.base.Function;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.CellContainer;
 import jetbrains.jetpad.cell.completion.Completion;
-import jetbrains.jetpad.cell.position.PositionHandler;
 import jetbrains.jetpad.cell.position.Positions;
 import jetbrains.jetpad.cell.text.TextEditing;
 import jetbrains.jetpad.cell.trait.CellTrait;
@@ -31,6 +30,7 @@ import jetbrains.jetpad.event.Event;
 import jetbrains.jetpad.event.Key;
 import jetbrains.jetpad.event.KeyEvent;
 import jetbrains.jetpad.event.KeyStrokeSpecs;
+import jetbrains.jetpad.hybrid.parser.ErrorToken;
 import jetbrains.jetpad.hybrid.parser.Token;
 
 import java.util.List;
@@ -160,9 +160,12 @@ class TokenCellTraits {
             (prev != null && (prev.noSpaceToRight() || current.noSpaceToLeft()) ||
             (next != null && (next.noSpaceToLeft()) || current.noSpaceToRight()))) {
           tokenOperations(cell).deleteToken(cell, 0).run();
-          event.consume();
-          return;
+        } else {
+          tokenOperations(cell).replaceToken(cell, new ErrorToken("")).run();
         }
+
+        event.consume();
+        return;
       }
 
       super.onCellTraitEvent(cell, spec, event);

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
@@ -122,6 +122,13 @@ class TokenOperations<SourceT> {
     }
   }
 
+  Runnable replaceToken(Cell contextCell, Token token) {
+    final int index = tokenViews().indexOf(contextCell);
+    tokens().remove(index);
+    tokens().add(index, token);
+    return select(index, FIRST);
+  }
+
   boolean canMerge(Cell contextCell, int delta) {
     final int index = tokenViews().indexOf(contextCell);
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
@@ -946,6 +946,16 @@ public class HybridEditorTest extends EditingTestCase {
     assertTrue(container.expr.get() instanceof MulExpr);
   }
 
+  @Test
+  public void emptyTokenCausesError() {
+    setTokens(new IdentifierToken("a"), Tokens.PLUS, new IdentifierToken("b"));
+
+    select(0, false);
+    backspace();
+
+    assertTrue(sync.target().hasError().get());
+  }
+
   private ValueToken createComplexToken() {
     return new ValueToken(new ComplexValueExpr(), new ComplexValueCloner());
   }


### PR DESCRIPTION
I believe this is better from the UX point of view.

Before this change if a user left an empty token (which is pretty hard to notice) and moved on editing the expression the parser would keep reparsing the expression successfully as if the token was still there. This is not only a potential source of confusion, but also causes de-synchronization of the model and its visual representation.

Now having an empty token makes the whole hybrid field become red and the model won’t be updated (if the parser stumbles on `ErrorToken`s as reasonable parsers do) until the empty token is removed or replaced with something else.