### PR TITLE
grammar: GrammarSugar.separated1

### DIFF
--- a/grammar/src/main/java/jetbrains/jetpad/grammar/GrammarSugar.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/GrammarSugar.java
@@ -86,7 +86,23 @@ public class GrammarSugar {
   public static NonTerminal separated(Symbol item, Symbol separator) {
     Grammar g = item.getGrammar();
     NonTerminal separated = g.newNonTerminal(g.uniqueName("separated_"));
-    NonTerminal sepSeq = g.newNonTerminal(g.uniqueName("separatedSeq_"));
+    g.newRule(separated, optional(separated1(item, separator))).setHandler(new RuleHandler() {
+      @Override
+      public Object handle(RuleContext ctx) {
+        List list = (List) ctx.get(0);
+        if (list.isEmpty()) {
+          return PersistentList.nil();
+        } else {
+          return list.get(0);
+        }
+      }
+    });
+    return separated;
+  }
+
+  public static NonTerminal separated1(Symbol item, Symbol separator) {
+    Grammar g = item.getGrammar();
+    NonTerminal sepSeq = g.newNonTerminal(g.uniqueName("separated1_"));
     g.newRule(sepSeq, item, star(seq(separator, item))).setHandler(new RuleHandler() {
       @Override
       public Object handle(RuleContext ctx) {
@@ -100,17 +116,6 @@ public class GrammarSugar {
         return result;
       }
     });
-    g.newRule(separated, optional(sepSeq)).setHandler(new RuleHandler() {
-      @Override
-      public Object handle(RuleContext ctx) {
-        List list = (List) ctx.get(0);
-        if (list.isEmpty()) {
-          return PersistentList.nil();
-        } else {
-          return list.get(0);
-        }
-      }
-    });
-    return separated;
+    return sepSeq;
   }
 }

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
@@ -93,4 +93,19 @@ public class GrammarSugarTest {
     assertEquals("[id]", "" + parser.parse(asTokens(id)));
     assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
   }
+
+  @Test
+  public void separated1Part() {
+    Grammar g = new Grammar();
+    Terminal id = g.newTerminal("id");
+    Terminal comma = g.newTerminal(",");
+    g.newRule(g.getStart(), separated1(id, comma));
+
+    LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
+
+    assertFalse(parser.parse(new Terminal[0]));
+    assertFalse(parser.parse(comma));
+    assertEquals("[id]", "" + parser.parse(asTokens(id)));
+    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+  }
 }


### PR DESCRIPTION
This is [`sepBy1`](https://hackage.haskell.org/package/parsec/docs/Text-Parsec-Combinator.html#v:sepBy1) from parsec.

`separated1` is a more basic operation than `separated` as the latter can be easily implemented through the former, but not the other way around.