### PR TITLE
grammar: New combinators

### DIFF
--- a/grammar/src/main/java/jetbrains/jetpad/grammar/PersistentList.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/PersistentList.java
@@ -16,7 +16,6 @@
 package jetbrains.jetpad.grammar;
 
 import java.util.AbstractList;
-import java.util.List;
 
 class PersistentList<ValueT> extends AbstractList<ValueT> {
   static <ValueT> PersistentList<ValueT> nil() {
@@ -31,6 +30,15 @@ class PersistentList<ValueT> extends AbstractList<ValueT> {
     result.myHead = head;
     result.myTail = tail;
     result.mySize = tail.size() + 1;
+    return result;
+  }
+
+  static <ValueT> PersistentList<ValueT> reversed(PersistentList<ValueT> list) {
+    PersistentList<ValueT> result = PersistentList.nil();
+    while (!list.myNil) {
+      result = PersistentList.cons(list.myHead, result);
+      list = list.myTail;
+    }
     return result;
   }
 

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
@@ -89,8 +89,61 @@ public class GrammarSugarTest {
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
     assertFalse(parser.parse(comma));
+    assertFalse(parser.parse(id, comma));
+    assertFalse(parser.parse(id, comma, id, comma));
     assertEquals("[]", "" + parser.parse(asTokens()));
     assertEquals("[id]", "" + parser.parse(asTokens(id)));
     assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+  }
+
+  @Test
+  public void separated1Part() {
+    Grammar g = new Grammar();
+    Terminal id = g.newTerminal("id");
+    Terminal comma = g.newTerminal(",");
+    g.newRule(g.getStart(), separated(id, comma, true));
+
+    LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
+
+    assertFalse(parser.parse(new Terminal[0]));
+    assertFalse(parser.parse(comma));
+    assertFalse(parser.parse(id, comma));
+    assertFalse(parser.parse(id, comma, id, comma));
+    assertEquals("[id]", "" + parser.parse(asTokens(id)));
+    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+  }
+
+  @Test
+  public void terminatedPart() {
+    Grammar g = new Grammar();
+    Terminal id = g.newTerminal("id");
+    Terminal comma = g.newTerminal(",");
+    g.newRule(g.getStart(), terminated(id, comma));
+
+    LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
+
+    assertFalse(parser.parse(new Terminal[0]));
+    assertFalse(parser.parse(comma));
+    assertFalse(parser.parse(id));
+    assertFalse(parser.parse(id, comma, id));
+    assertEquals("[id]", "" + parser.parse(asTokens(id, comma)));
+    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id, comma)));
+  }
+
+  @Test
+  public void terminatedTrailingOptionalPart() {
+    Grammar g = new Grammar();
+    Terminal id = g.newTerminal("id");
+    Terminal comma = g.newTerminal(",");
+    g.newRule(g.getStart(), terminated(id, comma, true));
+
+    LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
+
+    assertFalse(parser.parse(new Terminal[0]));
+    assertFalse(parser.parse(comma));
+    assertEquals("[[id], []]", "" + parser.parse(asTokens(id)));
+    assertEquals("[[id, id], []]", "" + parser.parse(asTokens(id, comma, id)));
+    assertEquals("[[id], [,]]", "" + parser.parse(asTokens(id, comma)));
+    assertEquals("[[id, id], [,]]", "" + parser.parse(asTokens(id, comma, id, comma)));
   }
 }


### PR DESCRIPTION
Like `separated` but allows for the trailing separator (think Python tuples).

This is [`sepEndBy`](https://hackage.haskell.org/package/parsec-3.1.7/docs/Text-Parsec-Combinator.html#v:sepEndBy) from parsec.