### PR TITLE
add assertion that target cell is empty in BaseProjectionalSynchonizer

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -77,6 +77,9 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
       Cell target,
       List<Cell> targetList,
       MapperFactory<SourceItemT, Cell> factory) {
+    if (!(target.children().isEmpty())) {
+      throw new IllegalStateException("target cell for projectional synchonizer should be initially empty");
+    }
     myMapper = mapper;
     myTarget = target;
     myTargetList = targetList;


### PR DESCRIPTION
Fisrt, I found natural to add such an assert after investigating code in BaseProjectionalSynchronizer. Second, if target cell isn't empty, placeholder logic is broken: synchonizer will remove some targets child cell instead of placeholder.