### PR TITLE
BECAME_EMPTY is not fired for clearSelection()

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -200,7 +200,7 @@ public class TextEditingTrait extends TextNavigationTrait {
     int from = Math.min(selStart, caret);
     int to = Math.max(selStart, caret);
 
-    cell.text().set(text.substring(0, from) + text.substring(to));
+    setText(cell, text.substring(0, from) + text.substring(to));
     cell.caretPosition().set(from);
     cell.selectionVisible().set(false);
   }

--- a/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
@@ -16,7 +16,10 @@
 package jetbrains.jetpad.cell.text;
 
 import jetbrains.jetpad.base.Runnables;
+import jetbrains.jetpad.base.Value;
 import jetbrains.jetpad.cell.trait.CellTrait;
+import jetbrains.jetpad.cell.trait.CellTraitEventSpec;
+import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.completion.CompletionItem;
 import jetbrains.jetpad.completion.CompletionParameters;
 import jetbrains.jetpad.completion.CompletionSupplier;
@@ -508,6 +511,31 @@ public class TextEditingTest extends EditingTestCase {
   }
 
   @Test
+  public void becameEmptyFiredForClearSelection() {
+    final Value<Boolean> becameEmptyFired = new Value<>(false);
+    textView.addTrait(new CellTrait() {
+      @Override
+      public void onCellTraitEvent(Cell cell, CellTraitEventSpec<?> spec, Event event) {
+        if (spec == Cells.BECAME_EMPTY) {
+          becameEmptyFired.set(true);
+          event.consume();
+          return;
+        }
+        super.onCellTraitEvent(cell, spec, event);
+      }
+    });
+
+    textView.text().set("TestText");
+    textView.caretPosition().set(8);
+    textView.selectionStart().set(0);
+    textView.selectionVisible().set(true);
+    press(Key.BACKSPACE);
+
+    assertEquals("", textView.text().get());
+    assertTrue(becameEmptyFired.get());
+  }
+
+  @Test
   public void textClearOnEmpty() {
     textView.addTrait(new CellTrait() {
       @Override
@@ -526,7 +554,6 @@ public class TextEditingTest extends EditingTestCase {
     assertFalse(event.isConsumed());
     assertEquals("", textView.text().get());
   }
-
 
   @Test
   public void textPaste() {


### PR DESCRIPTION
It's fired in other cases (backspace, ctrl-delete) but not in this one (select all and then backspace or delete). As a result we have different behavior in a hybrid editor for these cases.