### PR TITLE
provide actual edt to MessageTrait

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/message/MessageController.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/message/MessageController.java
@@ -42,7 +42,7 @@ public final class MessageController {
 
   public static Registration install(CellContainer container, MessageStyler styler) {
     MessageController controller = new MessageController(container);
-    MessageTrait trait = new MessageTrait(container.getEdt(), new StyleApplicator(styler));
+    MessageTrait trait = new MessageTrait(container, new StyleApplicator(styler));
     return controller.install(trait);
   }
 


### PR DESCRIPTION
As appropriate CellContainerPeer is provided to CellContainer only after the CellContainer mapper is attached, MessageTrait could get NullEventDispatchThread instance.