### PR TITLE
revert c6fee99 : don't set specific font-size for any domCell element.

### DIFF
--- a/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
+++ b/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
@@ -77,6 +77,7 @@
 }
 
 .domCell {
+  font-size: 12px;
   user-select: text;
   -moz-user-select: text;
   -webkit-user-select: text;


### PR DESCRIPTION
I'm reverting this because there was code that relied on having font-size not being 0. Either way, I have a better fix coming in next. 