### PR TITLE
DP-697 New tests: hybrid synchronizers write to list items transformed to properties

### DIFF
--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.hybrid;
 
 import com.google.common.collect.Range;
+import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.EditingTestCase;
 import jetbrains.jetpad.cell.HorizontalCell;
@@ -44,7 +45,7 @@ import jetbrains.jetpad.hybrid.util.HybridWrapperRole;
 import jetbrains.jetpad.mapper.Mapper;
 import jetbrains.jetpad.model.composite.Composites;
 import jetbrains.jetpad.projectional.util.RootController;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,17 +58,24 @@ import static org.junit.Assert.*;
 
 public class HybridEditorTest extends EditingTestCase {
   private ExprContainer container = new ExprContainer();
+  private Registration registration;
   private ExprContainerMapper mapper = new ExprContainerMapper(container);
   private HybridSynchronizer<Expr> sync;
   private Cell myTargetCell;
 
   @Before
   public void init() {
-    RootController.install(myCellContainer);
+    registration = RootController.install(myCellContainer);
     mapper.attachRoot();
     myCellContainer.root.children().add(myTargetCell = mapper.getTarget());
     CellActions.toFirstFocusable(mapper.getTarget()).run();
     sync = mapper.hybridSync;
+  }
+
+  @After
+  public void dispose() {
+    mapper.detachRoot();
+    registration.remove();
   }
 
   @Test

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorWithTransformedListTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorWithTransformedListTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.cell.EditingTestCase;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.event.Key;
+import jetbrains.jetpad.event.ModifierKey;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprListMapper;
+import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+import jetbrains.jetpad.projectional.util.RootController;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class HybridEditorWithTransformedListTest extends EditingTestCase {
+  private ExprList exprList = new ExprList();
+  private Registration registration;
+  private ExprListMapper rootMapper = new ExprListMapper(exprList);
+
+  @Before
+  public void init() {
+    exprList.expr.add(new EmptyExpr());
+    exprList.expr.add(new EmptyExpr());
+    registration = RootController.install(myCellContainer);
+    rootMapper.attachRoot();
+    myCellContainer.root.children().add(rootMapper.getTarget());
+    CellActions.toFirstFocusable(rootMapper.getTarget()).run();
+  }
+
+  @After
+  public void dispose() {
+    rootMapper.detachRoot();
+    registration.remove();
+  }
+
+  @Test
+  public void typeCorrect() {
+    type("id");
+    down();
+    type("1+2");
+    assertTrue(exprList.expr.get(0) instanceof IdExpr);
+    assertTrue(exprList.expr.get(1) instanceof PlusExpr);
+  }
+
+  @Test
+  public void typeIncorrect() {
+    type("id+");
+    down();
+    type("+");
+    assertTrue(exprList.expr.get(0) instanceof IdExpr);
+    assertEquals(asList(Tokens.ID, Tokens.PLUS), rootMapper.getItemsSynchronizers().get(0).tokens());
+    assertTrue(exprList.expr.get(1) instanceof EmptyExpr);
+    assertEquals(asList(Tokens.PLUS), rootMapper.getItemsSynchronizers().get(1).tokens());
+  }
+
+  @Test
+  public void clearItemToEmpty() {
+    type("0");
+    down();
+    type("1");
+    backspace();
+    assertEquals(Integer.valueOf(0), ((NumberExpr) exprList.expr.get(0)).value.get());
+    assertTrue(exprList.expr.get(1) instanceof EmptyExpr);
+  }
+
+  @Test
+  public void addItem() {
+    type("0");
+    down();
+    type("1");
+    enter();
+    type("2");
+    assertEquals(3, exprList.expr.size());
+    for (int i = 0; i < 3; i++) {
+      assertEquals(Integer.valueOf(i), ((NumberExpr) exprList.expr.get(i)).value.get());
+    }
+  }
+
+  @Test
+  public void removeItemWithDel() {
+    type("0");
+    down();
+    type("1");
+    up();
+    del();
+    assertEquals(1, exprList.expr.size());
+    assertEquals(Integer.valueOf(0), ((NumberExpr) exprList.expr.get(0)).value.get());
+  }
+
+  @Test
+  public void removeItemWithBackspace() {
+    type("0");
+    down();
+    type("1");
+    left();
+    backspace();
+    assertEquals(1, exprList.expr.size());
+    assertEquals(Integer.valueOf(1), ((NumberExpr) exprList.expr.get(0)).value.get());
+  }
+
+  @Test
+  public void removeTwoItems() {
+    type("0");
+    down();
+    type("1");
+    enter();
+    type("2");
+    left();
+    press(Key.UP, ModifierKey.SHIFT);
+    press(Key.UP, ModifierKey.SHIFT);
+    del();
+    assertEquals(1, exprList.expr.size());
+    assertEquals(Integer.valueOf(2), ((NumberExpr) exprList.expr.get(0)).value.get());
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/TestAppMain.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/TestAppMain.java
@@ -25,6 +25,10 @@ import jetbrains.jetpad.projectional.util.RootController;
 
 public class TestAppMain {
   public static void main(String[] args) {
+    /*
+     * To test expressions list, use ExprList and ExprListMapper,
+     * and add some expressions to ExprList.
+     */
     ExprContainer model = new ExprContainer();
     Mapper<?, ? extends Cell> rootMapper = new ExprContainerMapper(model);
     rootMapper.attachRoot();

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprContainerMapper.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprContainerMapper.java
@@ -15,13 +15,12 @@
  */
 package jetbrains.jetpad.hybrid.testapp.mapper;
 
-import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.HorizontalCell;
 import jetbrains.jetpad.hybrid.HybridEditorSpec;
 import jetbrains.jetpad.hybrid.HybridSynchronizer;
-import jetbrains.jetpad.hybrid.testapp.model.*;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.ExprContainer;
 import jetbrains.jetpad.mapper.Mapper;
-import jetbrains.jetpad.mapper.MapperFactory;
 import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.ValueProperty;
 
@@ -32,25 +31,7 @@ public class ExprContainerMapper extends Mapper<ExprContainer, HorizontalCell> {
   public ExprContainerMapper(ExprContainer source) {
     super(source, new HorizontalCell());
     hybridSync = new HybridSynchronizer<>(this, getSource().expr, getTarget(), hybridSyncSpec);
-
-    hybridSync.setMapperFactory(new MapperFactory<Object, Cell>() {
-      @Override
-      public Mapper<?, ? extends Cell> createMapper(Object source) {
-        if (source instanceof PosValueExpr) {
-          return new PosValueExprMapper((PosValueExpr) source);
-        }
-        if (source instanceof ValueExpr) {
-          return new ValueExprMapper((ValueExpr) source);
-        }
-        if (source instanceof AsyncValueExpr) {
-          return new AsyncValueExprMapper((AsyncValueExpr) source);
-        }
-        if (source instanceof ComplexValueExpr) {
-          return new ComplexValueExprMapper((ComplexValueExpr) source);
-        }
-        return null;
-      }
-    });
+    hybridSync.setMapperFactory(new ExprMapperFactory());
   }
 
   @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprListMapper.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprListMapper.java
@@ -1,0 +1,106 @@
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import com.google.common.base.Function;
+import com.google.common.base.Supplier;
+import com.google.common.collect.Lists;
+import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.cell.HorizontalCell;
+import jetbrains.jetpad.cell.VerticalCell;
+import jetbrains.jetpad.hybrid.HybridSynchronizer;
+import jetbrains.jetpad.hybrid.testapp.model.EmptyExpr;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.ExprList;
+import jetbrains.jetpad.mapper.Mapper;
+import jetbrains.jetpad.mapper.MapperFactory;
+import jetbrains.jetpad.mapper.MappingContext;
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.property.Properties;
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ValueProperty;
+import jetbrains.jetpad.model.transform.Transformation;
+import jetbrains.jetpad.model.transform.Transformers;
+import jetbrains.jetpad.projectional.cell.ProjectionalRoleSynchronizer;
+import jetbrains.jetpad.projectional.cell.ProjectionalSynchronizers;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class ExprListMapper extends Mapper<ExprList, Cell> {
+  private Transformation<ObservableList<Expr>, ObservableList<Property<Expr>>> myTransformation;
+  private ProjectionalRoleSynchronizer<ExprList, Property<Expr>> myRoleSync;
+
+  public ExprListMapper(ExprList source) {
+    super(source, new VerticalCell());
+  }
+
+  @Override
+  protected void onBeforeAttach(MappingContext ctx) {
+    super.onBeforeAttach(ctx);
+    myTransformation = Transformers.<Expr>toPropsListTwoWay().transform(getSource().expr);
+  }
+
+  @Override
+  protected void registerSynchronizers(SynchronizersConfiguration conf) {
+    super.registerSynchronizers(conf);
+    myRoleSync = ProjectionalSynchronizers.forRole(this, myTransformation.getTarget(), getTarget(), new MapperFactory<Property<Expr>, Cell>() {
+      @Override
+      public Mapper<? extends Property<Expr>, ? extends Cell> createMapper(Property<Expr> exprAsProperty) {
+        return new ExprMapper(exprAsProperty);
+      }
+    });
+    myRoleSync.setItemFactory(new Supplier<Property<Expr>>() {
+      @Override
+      public Property<Expr> get() {
+        return new ValueProperty<Expr>(new EmptyExpr());
+      }
+    });
+    conf.add(myRoleSync);
+  }
+
+  @Override
+  protected void onDetach() {
+    myTransformation.dispose();
+    super.onDetach();
+  }
+
+  public List<HybridSynchronizer<Expr>> getItemsSynchronizers() {
+    return Lists.transform(myRoleSync.getMappers(),
+        new Function<Mapper<? extends Property<Expr>, ? extends Cell>, HybridSynchronizer<Expr>>() {
+          @Nullable
+          @Override
+          public HybridSynchronizer<Expr> apply(@Nullable Mapper<? extends Property<Expr>, ? extends Cell> exprPropMapper) {
+            return ((ExprMapper) exprPropMapper).myHybridSync;
+          }
+        });
+  }
+
+  private static class ExprMapper extends Mapper<Property<Expr>, Cell> {
+    private HybridSynchronizer<Expr> myHybridSync;
+
+    public ExprMapper(Property<Expr> source) {
+      super(source, new HorizontalCell());
+    }
+
+    @Override
+    public void registerSynchronizers(SynchronizersConfiguration conf) {
+      super.registerSynchronizers(conf);
+      Property<Expr> nullSubstituting = Properties.map(getSource(),
+          new Function<Expr, Expr>() {
+            @Nullable
+            @Override
+            public Expr apply(@Nullable Expr expr) {
+              return expr instanceof EmptyExpr ? null : expr;
+            }
+          }, new Function<Expr, Expr>() {
+            @Nullable
+            @Override
+            public Expr apply(@Nullable Expr expr) {
+              return expr == null ? new EmptyExpr() : expr;
+            }
+          });
+      myHybridSync = new HybridSynchronizer<>(this, nullSubstituting, getTarget(), new ExprHybridEditorSpec());
+      myHybridSync.setMapperFactory(new ExprMapperFactory());
+      conf.add(myHybridSync);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+import jetbrains.jetpad.mapper.Mapper;
+import jetbrains.jetpad.mapper.MapperFactory;
+
+class ExprMapperFactory implements MapperFactory<Object,Cell> {
+  @Override
+  public Mapper<? extends Expr, ? extends Cell> createMapper(Object source) {
+    if (source instanceof PosValueExpr) {
+      return new PosValueExprMapper((PosValueExpr) source);
+    }
+    if (source instanceof ValueExpr) {
+      return new ValueExprMapper((ValueExpr) source);
+    }
+    if (source instanceof AsyncValueExpr) {
+      return new AsyncValueExprMapper((AsyncValueExpr) source);
+    }
+    if (source instanceof ComplexValueExpr) {
+      return new ComplexValueExprMapper((ComplexValueExpr) source);
+    }
+    throw new IllegalArgumentException("Unknown source: " + source);
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/EmptyExpr.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/EmptyExpr.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.model;
+
+public class EmptyExpr extends Expr {
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/ExprList.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/ExprList.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2015 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.model;
+
+import jetbrains.jetpad.model.children.ChildList;
+
+public class ExprList extends ExprNode {
+  public final ChildList<ExprList, Expr> expr = new ChildList<>(this);
+}


### PR DESCRIPTION
Compared to previous request:

* `ExprMapperFactory` visibility level lowered to package-private.

About `ExprListMapper`: this is a root mapper used outside the package, just like existing `ExprContainerMaper`. They both have to be `public`.