### PR TITLE
token.copy()

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
@@ -61,7 +61,7 @@ import static jetbrains.jetpad.model.composite.Composites.firstFocusable;
 import static jetbrains.jetpad.model.composite.Composites.lastFocusable;
 
 public class HybridSynchronizer<SourceT> implements Synchronizer {
-  public static final CellTraitPropertySpec<Runnable> ON_LAST_ITEM_DELETED = new CellTraitPropertySpec<Runnable>("onLastItemDeleted");
+  public static final CellTraitPropertySpec<Runnable> ON_LAST_ITEM_DELETED = new CellTraitPropertySpec<>("onLastItemDeleted");
 
   static final CellTraitPropertySpec<HybridSynchronizer<?>> HYBRID_SYNCHRONIZER = new CellTraitPropertySpec<>("hybridSynchronizer");
 
@@ -344,11 +344,7 @@ public class HybridSynchronizer<SourceT> implements Synchronizer {
 
         List<Token> result = new ArrayList<>();
         for (Token t : tokens()) {
-          if (t instanceof ValueToken) {
-            result.add(((ValueToken) t).copy());
-          } else {
-            result.add(t);
-          }
+          result.add(t.copy());
         }
         return new HybridCellState(result);
       }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenListEditor.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenListEditor.java
@@ -28,7 +28,6 @@ import jetbrains.jetpad.model.property.ReadableProperty;
 import jetbrains.jetpad.model.property.ValueProperty;
 import jetbrains.jetpad.hybrid.parser.ParsingContext;
 import jetbrains.jetpad.hybrid.parser.Token;
-import jetbrains.jetpad.hybrid.parser.ValueToken;
 import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinterContext;
 import jetbrains.jetpad.hybrid.parser.prettyprint.ParseNode;
 
@@ -136,11 +135,7 @@ class TokenListEditor<SourceT> {
     } else {
       List<Token> toParse = new ArrayList<>();
       for (Token t : tokens) {
-        if (t instanceof ValueToken) {
-          toParse.add(((ValueToken) t).copy());
-        } else {
-          toParse.add(t);
-        }
+        toParse.add(t.copy());
       }
 
       SourceT result = mySpec.get().getParser().parse(new ParsingContext(toParse));

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/BaseToken.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/BaseToken.java
@@ -30,4 +30,9 @@ public abstract class BaseToken implements Token {
   public boolean isRtOnEnd() {
     return false;
   }
+
+  @Override
+  public Token copy() {
+    return this;
+  }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/Token.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/Token.java
@@ -25,4 +25,6 @@ public interface Token {
   boolean isRtOnEnd();
 
   String text();
+
+  Token copy();
 }


### PR DESCRIPTION
Before only ValueToken had copy(). This allows us to simplify code a little in a couple of places. And it will be easier for clients to copy a list of tokens.