### PR TITLE
new z-ordering for text editor layout

### DIFF
--- a/domUtil/src/main/java/jetbrains/jetpad/projectional/domUtil/DomTextEditor.java
+++ b/domUtil/src/main/java/jetbrains/jetpad/projectional/domUtil/DomTextEditor.java
@@ -51,14 +51,14 @@ public class DomTextEditor {
 
     myTextContainer = DOM.createSpan();
     Style textStyle = myTextContainer.getStyle();
-    textStyle.setZIndex(2);
+    textStyle.setZIndex(10);
     textStyle.setWhiteSpace(Style.WhiteSpace.NOWRAP);
     myRoot.appendChild(myTextContainer);
 
     Element caretDiv = DOM.createDiv();
     Style caretStyle = caretDiv.getStyle();
     caretStyle.setPosition(Style.Position.ABSOLUTE);
-    caretStyle.setZIndex(2);
+    caretStyle.setZIndex(10);
     myRoot.appendChild(caretDiv);
     myCaretDiv = caretDiv;
 


### PR DESCRIPTION
Needed to properly draw additional cursors.
Increased value to 10 to avoid further changes if we would add more decoration types.