### PR TITLE
removed "width: fit-content" for ".vertical > div" and ".domCell"

### DIFF
--- a/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
+++ b/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
@@ -64,11 +64,6 @@
 .vertical > div {
   display: block;
   font-size: 0px;
-
-
-  width: fit-content;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
 }
 
 .horizontal > div > .vertical {
@@ -83,10 +78,6 @@
   -webkit-user-select: text;
   -ms-user-select: text;
   -webkit-user-select: text;
-
-  width: fit-content;
-  width: -webkit-fit-content;
-  width: -moz-fit-content;
 }
 
 .indented {


### PR DESCRIPTION
Checked census-analyzer and workflow. Actually didn't notice any differences in the presentation.