### PR TITLE
Focus tokens after reprinting on split

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
@@ -234,8 +234,8 @@ class TokenOperations<SourceT> {
 
         tokens().set(index, firstToken != null ? firstToken : new ErrorToken(firstTokenText));
         tokens().add(index + 1, secondToken != null ? secondToken : new ErrorToken(secondTokenText));
-        select(index + 1, FIRST).run();
         mySync.tokenListEditor().updateToPrintedTokens();
+        select(index + 1, FIRST).run();
         return true;
       }
     }
@@ -256,8 +256,8 @@ class TokenOperations<SourceT> {
       tokens().add(index, first);
       tokens().add(index + 1, second);
       tokens().add(index + 2, third);
-      select(index + 1, LAST).run();
       mySync.tokenListEditor().updateToPrintedTokens();
+      select(index + 1, LAST).run();
       return true;
     }
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorTest.java
@@ -28,11 +28,7 @@ import jetbrains.jetpad.cell.message.MessageController;
 import jetbrains.jetpad.cell.position.Positions;
 import jetbrains.jetpad.cell.util.CellState;
 import jetbrains.jetpad.cell.util.CellStateHandler;
-import jetbrains.jetpad.completion.BaseCompletionParameters;
-import jetbrains.jetpad.completion.CompletionController;
-import jetbrains.jetpad.completion.CompletionItem;
-import jetbrains.jetpad.completion.CompletionParameters;
-import jetbrains.jetpad.completion.CompletionSupplier;
+import jetbrains.jetpad.completion.*;
 import jetbrains.jetpad.event.Key;
 import jetbrains.jetpad.event.KeyEvent;
 import jetbrains.jetpad.event.KeyStrokeSpecs;
@@ -51,7 +47,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
 import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
@@ -570,6 +565,17 @@ public class HybridEditorTest extends EditingTestCase {
     type(" ");
 
     assertTokens(Tokens.ID, Tokens.MUL, new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
+  }
+
+  @Test
+  public void tokenFocusAfterReparseAndSplitGivesDifferentTokens() {
+    setTokens(new IdentifierToken("func("), Tokens.RP);
+
+    select(0, false);
+    left();
+    type(" ");
+
+    assertEquals(0, sync.focusedIndex());
   }
 
   @Test

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -298,6 +298,12 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
         TokenCompletionItems items = new TokenCompletionItems(tokenHandler);
         result.addAll(items.forTokens(Tokens.ID, Tokens.INCREMENT, Tokens.FACTORIAL, Tokens.PLUS, Tokens.MUL, Tokens.LP, Tokens.RP, Tokens.DOT));
         result.add(items.forNumber());
+        result.add(new SimpleCompletionItem("func") {
+          @Override
+          public Runnable complete(String text) {
+            return tokenHandler.apply(new IdentifierToken("func"));
+          }
+        });
         result.add(new SimpleCompletionItem("value") {
           @Override
           public Runnable complete(String text) {


### PR DESCRIPTION
In case after reprinting some tokens change, if one of those changed
tokens was focused, we want to focus its replacement.