### PR TITLE
calculating isHome() and isEnd() using children of a cell

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/position/CellDefaultPositionHandler.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/position/CellDefaultPositionHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.cell.position;
+
+import jetbrains.jetpad.cell.Cell;
+
+final class CellDefaultPositionHandler extends DefaultPositionHandler {
+
+  private final Cell myCell;
+
+  CellDefaultPositionHandler(Cell cell) {
+    myCell = cell;
+  }
+
+  @Override
+  public boolean isHome() {
+    Cell childCell = myCell.firstChild();
+    return childCell == null ? super.isHome() : childCell.get(PositionHandler.PROPERTY).isHome();
+  }
+
+  @Override
+  public boolean isEnd() {
+    Cell childCell = myCell.lastChild();
+    return childCell == null ? super.isEnd() : childCell.get(PositionHandler.PROPERTY).isEnd();
+  }
+
+}

--- a/cell/src/main/java/jetbrains/jetpad/cell/position/DefaultPositionHandler.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/position/DefaultPositionHandler.java
@@ -21,6 +21,10 @@ import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
 public class DefaultPositionHandler implements PositionHandler {
+
+  protected DefaultPositionHandler() {
+  }
+
   @Override
   public boolean isHome() {
     return false;

--- a/cell/src/main/java/jetbrains/jetpad/cell/position/PositionHandler.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/position/PositionHandler.java
@@ -23,15 +23,15 @@ import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
 import jetbrains.jetpad.model.property.Property;
 
 public interface PositionHandler {
-  public static PositionHandler EMPTY = new EmptyPositionHandler();
+  PositionHandler EMPTY = new EmptyPositionHandler();
 
-  public static final CellTraitPropertySpec<PositionHandler> PROPERTY = new CellTraitPropertySpec<>("positionHandler", new Function<Cell, PositionHandler>() {
+  CellTraitPropertySpec<PositionHandler> PROPERTY = new CellTraitPropertySpec<>("positionHandler", new Function<Cell, PositionHandler>() {
     @Override
     public PositionHandler apply(Cell input) {
       if (TextEditing.isTextEditor(input)) {
         return new TextPositionHandler(TextEditing.textEditor(input));
       }
-      return new DefaultPositionHandler();
+      return new CellDefaultPositionHandler(input);
     }
   });
 

--- a/cell/src/test/java/jetbrains/jetpad/cell/util/CellsTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/util/CellsTest.java
@@ -106,6 +106,13 @@ public class CellsTest extends BaseTestCase {
   }
 
   @Test
+  public void emptinessOfVerticalCell() {
+    VerticalCell cell = new VerticalCell();
+    cell.children().add(new TextCell());
+    assertTrue(Cells.isEmpty(cell));
+  }
+
+  @Test
   public void nextCellAfterAdd() {
     container.children().add(c1);
     container.children().add(c2);

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -25,6 +25,7 @@ import jetbrains.jetpad.cell.TextCell;
 import jetbrains.jetpad.cell.completion.Completion;
 import jetbrains.jetpad.cell.event.FocusEvent;
 import jetbrains.jetpad.cell.indent.IndentCell;
+import jetbrains.jetpad.cell.position.PositionHandler;
 import jetbrains.jetpad.cell.position.Positions;
 import jetbrains.jetpad.cell.text.TextEditing;
 import jetbrains.jetpad.cell.trait.CellTrait;
@@ -570,12 +571,15 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
       });
       String placeholderText =  myPlaceholderText != null ? myPlaceholderText : "<empty>";
 
+      Cell result;
       //todo this is tmp hack
       if (myTarget instanceof IndentCell) {
-        return CellFactory.indent(placeHolder, CellFactory.placeHolder(placeHolder, placeholderText));
+        result = CellFactory.indent(placeHolder, CellFactory.placeHolder(placeHolder, placeholderText));
       } else {
-        return CellFactory.horizontal(placeHolder, CellFactory.placeHolder(placeHolder, placeholderText));
+        result = CellFactory.horizontal(placeHolder, CellFactory.placeHolder(placeHolder, placeholderText));
       }
+      result.set(PositionHandler.PROPERTY, placeHolder.get(PositionHandler.PROPERTY));
+      return result;
     }
 
     private TextCell getPlaceHolder() {

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -882,6 +882,13 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertTrue(container.children.isEmpty());
   }
 
+  @Test
+  public void emptinessOfPlaceholder() {
+    EmptyCompositeChild emptyCompositeChild = new EmptyCompositeChild();
+    container.children.add(emptyCompositeChild);
+    assertTrue(Cells.isEmpty(getChild(0)));
+  }
+
   private Child get(int index) {
     return container.children.get(index);
   }
@@ -970,6 +977,10 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
 
         if (source instanceof CompositeChild) {
           return new CompositeChildMapper((CompositeChild) source);
+        }
+
+        if (source instanceof EmptyCompositeChild) {
+          return new EmptyCompositeChildMapper((EmptyCompositeChild) source);
         }
 
         if (source instanceof DeleteOnEmptyChild) {
@@ -1075,6 +1086,9 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     final ObservableList<Child> children = new ObservableArrayList<>();
   }
 
+  private class EmptyCompositeChild extends Child {
+    final ObservableList<Child> children = new ObservableArrayList<>();
+  }
 
   private class NonSelectableChild extends Child {
   }
@@ -1199,6 +1213,18 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     protected void registerSynchronizers(SynchronizersConfiguration conf) {
       super.registerSynchronizers(conf);
       conf.add(createSynchronizer(this, getTarget().children().get(1), getSource().children));
+    }
+  }
+
+  private class EmptyCompositeChildMapper extends Mapper<EmptyCompositeChild, HorizontalCell> {
+    private EmptyCompositeChildMapper(EmptyCompositeChild source) {
+      super(source, new HorizontalCell());
+    }
+
+    @Override
+    protected void registerSynchronizers(SynchronizersConfiguration conf) {
+      super.registerSynchronizers(conf);
+      conf.add(createSynchronizer(this, getTarget(), getSource().children));
     }
   }
 


### PR DESCRIPTION
It allows us to determine more easily (or automatically in some cases) that the compound cell is empty. 
Added test cases for both commits (failed before, passes after).
Ran "mvn clean install" for all four repositories (mapper, projectional, ot-model, datapad).