### PR TITLE
Introduced ValueTokenWithTextGen

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ValueToken.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ValueToken.java
@@ -33,6 +33,10 @@ public class ValueToken extends BaseToken {
     return myValue;
   }
 
+  ValueCloner cloner() {
+    return myCloner;
+  }
+
   public ValueToken copy() {
     return new ValueToken(myCloner.clone(myValue), myCloner);
   }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ValueTokenWithTextGen.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ValueTokenWithTextGen.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.parser;
+
+import com.google.common.base.Function;
+
+public class ValueTokenWithTextGen<ValueT> extends ValueToken {
+  private final Function<ValueT, String> myTextGenerator;
+
+  public ValueTokenWithTextGen(ValueT val, ValueCloner<ValueT>  cloner, Function<ValueT, String> textGen) {
+    super(val, cloner);
+    myTextGenerator = textGen;
+  }
+
+  @Override
+  public String text() {
+    return myTextGenerator.apply((ValueT) value());
+  }
+
+  @Override
+  public ValueTokenWithTextGen copy() {
+    return new ValueTokenWithTextGen<>((ValueT) cloner().clone(value()), cloner(), myTextGenerator);
+  }
+}


### PR DESCRIPTION
The new class is needed for textual copy/paste from/to hybrid editor implementation. After merge, I'll migrate hybrid editor specs from `ValueToken` to `ValueTokenWithTextGen` where needed, then I will finish copy/paste implementation in this repo.