### PR TITLE
scaled image (to show x2 image as x1 in awt like in webapp)

### DIFF
--- a/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ImageUtil.java
+++ b/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ImageUtil.java
@@ -1,0 +1,21 @@
+package jetbrains.jetpad.projectional.view.toAwt;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+
+final class ImageUtil {
+
+  static Image getScaledImage(Image image, int width, int height) {
+    BufferedImage bufferedImage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+    Graphics2D graphics = bufferedImage.createGraphics();
+    graphics.addRenderingHints(new RenderingHints(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY));
+    graphics.drawImage(image, 0, 0, width, height, null);
+    return bufferedImage;
+  }
+
+  private ImageUtil() {
+  }
+
+}

--- a/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
+++ b/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
@@ -623,7 +623,8 @@ public class ViewContainerComponent extends JComponent implements Scrollable {
           throw new RuntimeException(e);
         }
 
-        g.drawImage(image, bounds.origin.x, bounds.origin.y, new ImageObserver() {
+        Image scaledImage = ImageUtil.getScaledImage(image, bounds.dimension.x, bounds.dimension.y);
+        g.drawImage(scaledImage, bounds.origin.x, bounds.origin.y, new ImageObserver() {
           @Override
           public boolean imageUpdate(Image img, int infoflags, int x, int y, int width, int height) {
             return true;


### PR DESCRIPTION
Currently we generate 220 dpi x2 image (let's say 1200x800 px). In the webapp we show it x1 (600x400 px). In awt now we have to show it x2 and it's quite big. 
getScaledImage code is from here:
http://stackoverflow.com/questions/12475503/how-to-change-the-size-of-an-image