### PR TITLE
A way to clear a placeholder cell (role.clear())

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -535,7 +535,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
     }
 
     private Cell createPlaceholder() {
-      TextCell placeHolder = new TextCell();
+      final TextCell placeHolder = new TextCell();
       placeHolder.addTrait(new DerivedCellTrait() {
         @Override
         protected CellTrait getBase(Cell cell) {
@@ -562,6 +562,11 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
               @Override
               public Runnable set(SourceItemT target) {
                 return insertItem(target);
+              }
+
+              @Override
+              public void clear() {
+                placeHolder.text().set("");
               }
             });
           }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
@@ -37,8 +37,8 @@ import jetbrains.jetpad.mapper.RoleSynchronizer;
 import jetbrains.jetpad.mapper.Synchronizers;
 import jetbrains.jetpad.model.collections.list.ObservableList;
 import jetbrains.jetpad.model.composite.Composites;
+import jetbrains.jetpad.projectional.generic.BaseRole;
 import jetbrains.jetpad.projectional.generic.CollectionEditor;
-import jetbrains.jetpad.projectional.generic.Role;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -218,7 +218,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   }
 
   private CompletionSupplier getCurrentChildCompletion() {
-    return createCompletion(new Role<SourceItemT>() {
+    return createCompletion(new BaseRole<SourceItemT>() {
       @Override
       public SourceItemT get() {
         return mySource.get(getChildCells().indexOf(currentCell()));

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
@@ -34,7 +34,7 @@ import jetbrains.jetpad.mapper.RoleSynchronizer;
 import jetbrains.jetpad.mapper.Synchronizers;
 import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.WritableProperty;
-import jetbrains.jetpad.projectional.generic.Role;
+import jetbrains.jetpad.projectional.generic.BaseRole;
 
 import java.util.List;
 
@@ -126,7 +126,7 @@ class ProjectionalPropertySynchronizer<ContextT, SourceItemT> extends BaseProjec
   }
 
   private CompletionSupplier getCompletion() {
-    return createCompletion(new Role<SourceItemT>() {
+    return createCompletion(new BaseRole<SourceItemT>() {
       @Override
       public SourceItemT get() {
         return mySource.get();

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/generic/BaseRole.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/generic/BaseRole.java
@@ -15,8 +15,13 @@
  */
 package jetbrains.jetpad.projectional.generic;
 
-public interface Role<TargetT> {
-  TargetT get();
-  Runnable set(TargetT target);
-  void clear();
+public abstract class BaseRole<TargetT> implements Role<TargetT> {
+
+  protected BaseRole() {
+  }
+
+  @Override
+  public void clear() {
+  }
+
 }

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -50,6 +50,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -889,6 +890,16 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertTrue(Cells.isEmpty(getChild(0)));
   }
 
+  @Test
+  public void roleClear() {
+    container.children.add(new EmptyCompositeChild());
+
+    type("clea");
+    complete();
+
+    assertTrue(Cells.isEmpty(getChild(0)));
+  }
+
   private Child get(int index) {
     return container.children.get(index);
   }
@@ -1025,12 +1036,21 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
         return new CompletionSupplier() {
           @Override
           public List<CompletionItem> get(CompletionParameters cp) {
-            return Arrays.<CompletionItem>asList(new SimpleCompletionItem("item") {
+            List<CompletionItem> result = new ArrayList<>();
+            result.add(new SimpleCompletionItem("item") {
               @Override
               public Runnable complete(String text) {
                 return target.set(new NonEmptyChild());
               }
             });
+            result.add(new SimpleCompletionItem("clear") {
+              @Override
+              public Runnable complete(String text) {
+                target.clear();
+                return Runnables.EMPTY;
+              }
+            });
+            return result;
           }
 
           @Override


### PR DESCRIPTION
We have a case where on completion we change the structure elsewhere (we complete "else" inside the if statement but the else part is added to the enclosing if statement and we also put the focus there). 
We need a way to clear the placeholder cell, otherwise it will contain the completion prefix (e.g. "el"). 
We could have used role.set(null) but role.clear() conveys the intention more clearly.
The default implementation of role.clear() could be role.set(null) but I left it empty for now (the only usage now will be placeholder specific).
There are Role implementations outside this repository, they need to be updated (they could extend BaseRole).