### PR TITLE
Implemented a textual copypaste in hybrid editor

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
@@ -240,6 +240,7 @@ public abstract class Cell implements NavComposite<Cell>, HasVisibility, HasFocu
     newTraits[0] = trait;
     System.arraycopy(myCellTraits, 0, newTraits, 1, myCellTraits.length);
     myCellTraits = newTraits;
+    trait.onAdded(this);
     r.run();
     return new Registration() {
       @Override

--- a/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
@@ -232,6 +232,11 @@ public class CellContainer {
     dispatch(new PasteEvent(myContent), CellEventSpec.PASTE);
   }
 
+  // For tests
+  String getLastSeenText() {
+    return myLastSeenText;
+  }
+
   private void mouseEventHappened(MouseEvent e, CellEventSpec<MouseEvent> eventSpec) {
     Cell target = findCell(e.getLocation());
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditing.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditing.java
@@ -41,6 +41,7 @@ public class TextEditing {
   public static final CellTraitPropertySpec<Function<String, Runnable>> EXPAND_LEFT = new CellTraitPropertySpec<>("expandLeft", expansionProvider(Side.LEFT));
   public static final CellTraitPropertySpec<Function<String, Runnable>> EXPAND_RIGHT = new CellTraitPropertySpec<>("expandRight", expansionProvider(Side.RIGHT));
   public static final CellTraitPropertySpec<Supplier<Boolean>> AFTER_TYPE = new CellTraitPropertySpec<>("afterType");
+  public static final CellTraitPropertySpec<Supplier<Boolean>> AFTER_PASTE = new CellTraitPropertySpec<>("afterPaste");
 
   public static final CellTraitPropertySpec<Boolean> EAGER_COMPLETION = new CellTraitPropertySpec<>("eagerCompletion", false);
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -191,6 +191,7 @@ public class TextEditingTrait extends TextNavigationTrait {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     clearSelection(editor);
     pasteText(editor, newText.toString());
+    onAfterPaste(editor);
     event.consume();
   }
 
@@ -238,6 +239,14 @@ public class TextEditingTrait extends TextNavigationTrait {
     Supplier<Boolean> afterType = ((CellTextEditor) editor).getCell().get(TextEditing.AFTER_TYPE);
     if (afterType != null) {
       return afterType.get();
+    }
+    return false;
+  }
+
+  protected boolean onAfterPaste(TextEditor editor) {
+    Supplier<Boolean> afterPaste = ((CellTextEditor) editor).getCell().get(TextEditing.AFTER_PASTE);
+    if (afterPaste != null) {
+      return afterPaste.get();
     }
     return false;
   }

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
@@ -51,6 +51,11 @@ class ValidTextEditingTrait extends TextEditingTrait {
   }
 
   @Override
+  public void onAdded(Cell cell) {
+    validate(cell);
+  }
+
+  @Override
   public void onKeyPressed(Cell cell, KeyEvent event) {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     if (event.is(Key.ENTER) && !TextEditing.isEmpty(editor) && !isValid(editor)) {
@@ -74,11 +79,15 @@ class ValidTextEditingTrait extends TextEditingTrait {
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> e) {
     if (prop == TextCell.TEXT) {
-      CellTextEditor editor = TextEditing.cellTextEditor(cell);
-      MessageController.setBroken(cell, isValid(editor) ? null : "Cannot resolve '" + TextEditing.text(editor) + '\'');
+      validate(cell);
     }
 
     super.onPropertyChanged(cell, prop, e);
+  }
+
+  private void validate(Cell cell) {
+      CellTextEditor editor = TextEditing.cellTextEditor(cell);
+      MessageController.setBroken(cell, isValid(editor) ? null : "Cannot resolve '" + TextEditing.text(editor) + '\'');
   }
 
   @Override

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/CellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/CellTrait.java
@@ -33,6 +33,9 @@ public abstract class CellTrait {
   public static final Object NULL = new Object();
   public static final CellTrait[] EMPTY_ARRAY = new CellTrait[0];
 
+  public void onAdded(Cell cell) {
+  }
+
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {
   }
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
@@ -26,6 +26,13 @@ public abstract class CompositeCellTrait extends CellTrait {
   protected abstract CellTrait[] getBaseTraits(Cell cell);
 
   @Override
+  public void onAdded(Cell cell) {
+    for (CellTrait t : getBaseTraits(cell)) {
+      t.onAdded(cell);
+    }
+  }
+
+  @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {
     for (CellTrait t : getBaseTraits(cell)) {
       t.onPropertyChanged(cell, prop, event);

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/DerivedCellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/DerivedCellTrait.java
@@ -22,10 +22,13 @@ import jetbrains.jetpad.cell.event.FocusEvent;
 import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
-import javax.annotation.Nonnull;
-
 public abstract class DerivedCellTrait extends CellTrait {
   protected abstract CellTrait getBase(Cell cell);
+
+  @Override
+  public void onAdded(Cell cell) {
+    getBase(cell).onAdded(cell);
+  }
 
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {

--- a/cell/src/test/java/jetbrains/jetpad/cell/EditableCellContainer.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/EditableCellContainer.java
@@ -172,4 +172,8 @@ public class EditableCellContainer {
   public final void help() {
     press(Key.F1, ModifierKey.CONTROL);
   }
+
+  public String getLastSeenText() {
+    return container.getLastSeenText();
+  }
 }

--- a/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.*;
 public abstract class EditingTestCase extends BaseTestCase {
   protected final CellContainer myCellContainer = new CellContainer();
 
-  private EditableCellContainer myEditableCellContainer = new EditableCellContainer(myCellContainer);
+  protected EditableCellContainer myEditableCellContainer = new EditableCellContainer(myCellContainer);
 
   protected CellContainerToViewMapper getContainerMapper() {
     return myEditableCellContainer.mapper;

--- a/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.completion;
+
+public abstract class ByBoundsCompletionItem extends BaseCompletionItem {
+  private final String myPrefix;
+  private final String mySuffix;
+  private final String myVisibleText;
+
+  protected ByBoundsCompletionItem(String prefix, String suffix) {
+    myPrefix = prefix;
+    mySuffix = suffix;
+    myVisibleText = prefix + "..." + suffix;
+  }
+
+  @Override
+  public String visibleText(String text) {
+    return myVisibleText;
+  }
+
+  @Override
+  public boolean isStrictMatchPrefix(String text) {
+    return myPrefix.startsWith(text) || isPrefixedButNotSuffixed(text);
+  }
+
+  @Override
+  public boolean isMatch(String text) {
+    return isPrefixedAndSuffixed(text);
+  }
+
+  private boolean isPrefixedButNotSuffixed(String text) {
+    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == -1;
+  }
+
+  private boolean isPrefixedAndSuffixed(String text) {
+    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == (text.length() - mySuffix.length());
+  }
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.hybrid;
 
 import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
 import com.google.common.collect.Range;
 import jetbrains.jetpad.base.Handler;
 import jetbrains.jetpad.base.Registration;
@@ -285,7 +286,21 @@ public class HybridSynchronizer<SourceT> implements Synchronizer, ToCellMapping 
         int targetIndex;
         if (currentCell != null) {
           int currentCellIndex = myTargetList.indexOf(currentCell);
-          targetIndex = Positions.isHomePosition(currentCell) ? currentCellIndex : currentCellIndex + 1;
+          boolean home = Positions.isHomePosition(currentCell);
+          boolean end = Positions.isEndPosition(currentCell);
+          if (home && end) {
+            // One-char token which allows editing at only one side
+            if (currentCell instanceof TextTokenCell
+                && ((TextTokenCell) currentCell).noSpaceToLeft()) {
+              targetIndex = currentCellIndex + 1;
+            } else {
+              targetIndex = currentCellIndex;
+            }
+          } else if (home) {
+            targetIndex = currentCellIndex;
+          } else {
+            targetIndex = currentCellIndex + 1;
+          }
         } else {
           targetIndex = 0;
         }
@@ -314,6 +329,26 @@ public class HybridSynchronizer<SourceT> implements Synchronizer, ToCellMapping 
               return (T) Collections.unmodifiableList(tokens);
             }
             return null;
+          }
+
+          @Override
+          public String toString() {
+            StringBuilder joinedTokens = new StringBuilder();
+            Token prevToken = null;
+            for (Token currToken : tokens) {
+              if (prevToken != null && !prevToken.noSpaceToRight() && !currToken.noSpaceToLeft()) {
+                joinedTokens.append(' ');
+              }
+              String currText;
+              try {
+                currText = currToken.text();
+              } catch (UnsupportedOperationException e) {
+                return super.toString();
+              }
+              joinedTokens.append(currText);
+              prevToken = currToken;
+            }
+            return joinedTokens.toString();
           }
         };
       }
@@ -513,7 +548,7 @@ public class HybridSynchronizer<SourceT> implements Synchronizer, ToCellMapping 
   }
 
   private TextCell createPlaceholder() {
-    TextCell result = new TextCell();
+    final TextCell result = new TextCell();
     result.addTrait(new DerivedCellTrait() {
       @Override
       protected CellTrait getBase(Cell cell) {
@@ -521,10 +556,19 @@ public class HybridSynchronizer<SourceT> implements Synchronizer, ToCellMapping 
       }
 
       @Override
-      public Object get(Cell cell, CellTraitPropertySpec<?> spec) {
+      public Object get(final Cell cell, CellTraitPropertySpec<?> spec) {
         if (spec == TextEditing.EAGER_COMPLETION) return true;
 
         if (spec == Completion.COMPLETION) return tokenCompletion().placeholderCompletion(cell);
+
+        if (spec == TextEditing.AFTER_PASTE) {
+          return new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+              return tokenOperations().afterPaste(result);
+            }
+          };
+        }
 
         return super.get(cell, spec);
       }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -106,6 +106,15 @@ class TextTokenCell extends TextCell {
           };
         }
 
+        if (spec == TextEditing.AFTER_PASTE) {
+          return new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+              return tokenOperations(cell).afterPaste(TextTokenCell.this);
+            }
+          };
+        }
+
         return super.get(cell, spec);
       }
 

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
@@ -264,4 +264,19 @@ class TokenOperations<SourceT> {
     return false;
   }
 
+  boolean afterPaste(TextCell textView) {
+    Tokenizer<SourceT> tokenizer = new Tokenizer<>(mySync.editorSpec());
+    List<Token> newTokens = tokenizer.tokenize(textView.text().get());
+    int index;
+    if (!tokens().isEmpty()) {
+      index = tokenViews().indexOf(textView);
+      tokens().remove(index);
+    } else {
+      index = 0;
+    }
+    tokens().addAll(index, newTokens);
+    mySync.tokenListEditor().updateToPrintedTokens();
+    select(index + newTokens.size() - 1, LAST).run();
+    return true;
+  }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Function;
+import jetbrains.jetpad.base.Value;
+import jetbrains.jetpad.cell.completion.CompletionItems;
+import jetbrains.jetpad.completion.CompletionItem;
+import jetbrains.jetpad.completion.CompletionParameters;
+import jetbrains.jetpad.hybrid.parser.ErrorToken;
+import jetbrains.jetpad.hybrid.parser.Token;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+class Tokenizer<SourceT> {
+  private final HybridEditorSpec<SourceT> mySpec;
+
+  Tokenizer(HybridEditorSpec<SourceT> spec) {
+    mySpec = spec;
+  }
+
+  List<Token> tokenize(String input) {
+    TokensCollector tc = new TokensCollector();
+    for (char currentChar : input.toCharArray()) {
+      tc.append(currentChar);
+    }
+    tc.collectLastToken();
+    return tc.tokens;
+  }
+
+  private class TokensCollector {
+    private final TextMatcher textMatcher = new TextMatcher();
+    private final StringBuilder currentTokenCandidate = new StringBuilder();
+    private TextMatchResult currentMatchResult = pending("");
+    private final List<Token> tokens = new ArrayList<>();
+
+    private void append(char ch) {
+      if (CharMatcher.whitespace().matches(ch)) {
+        if (currentTokenCandidate.length() == 0) {
+           return;
+        }
+        if (currentMatchResult.noWayToComplete) {
+          tokens.add(currentMatchResult.pendingToken);
+          clear();
+          return;
+        }
+      }
+
+      TextMatchResult prevMatchResult = currentMatchResult;
+      currentTokenCandidate.append(ch);
+      updateMatchResult();
+      if (currentMatchResult.noWayToComplete && prevMatchResult.matchesSingleToken) {
+        tokens.add(prevMatchResult.singleMatchedToken);
+        clear();
+        append(ch);
+      }
+    }
+
+    private void collectLastToken() {
+      if (currentMatchResult.matchesSingleToken) {
+        tokens.add(currentMatchResult.singleMatchedToken);
+      } else if (currentMatchResult.isPendingTokenNonEmpty()) {
+        tokens.add(currentMatchResult.pendingToken);
+      }
+    }
+
+    private void clear() {
+      currentTokenCandidate.setLength(0);
+      currentMatchResult = pending("");
+    }
+
+    private void updateMatchResult() {
+      currentMatchResult = textMatcher.match(currentTokenCandidate.toString());
+    }
+  }
+
+  private class TextMatcher {
+    private final Value<Token> tokenHolder = new Value<>();
+    private final CompletionItems completionItems = new CompletionItems(
+        mySpec.getTokenCompletion(new Function<Token, Runnable>() {
+          @Nullable
+          @Override
+          public Runnable apply(@Nullable final Token token) {
+            return new Runnable() {
+              @Override
+              public void run() {
+                tokenHolder.set(token);
+              }
+            };
+          }
+        }).get(CompletionParameters.EMPTY));
+
+    private TextMatchResult match(String text) {
+      List<CompletionItem> basicMatches = completionItems.matches(text);
+      if (basicMatches.size() == 1) {
+        basicMatches.iterator().next().complete(text).run();
+        return singleMatched(tokenHolder.get());
+      } else {
+        boolean noWayToComplete = basicMatches.isEmpty() && completionItems.prefixedBy(text).isEmpty();
+        if (noWayToComplete) {
+          return error(text);
+        } else {
+          return pending(text);
+        }
+      }
+    }
+  }
+
+  private static TextMatchResult singleMatched(Token token) {
+    return new TextMatchResult(true, token, false, null);
+  }
+
+  private static TextMatchResult error(String text) {
+    return new TextMatchResult(false, null, true, new ErrorToken(text));
+  }
+
+  private static TextMatchResult pending(String text) {
+    return new TextMatchResult(false, null, false, new ErrorToken(text));
+  }
+
+  private static class TextMatchResult {
+    private final boolean matchesSingleToken;
+    private final Token singleMatchedToken;
+    private final boolean noWayToComplete;
+    private final ErrorToken pendingToken;
+    private TextMatchResult(boolean matchesSingleToken, Token singleMatchedToken, boolean noWayToComplete, ErrorToken pendingToken) {
+      this.matchesSingleToken = matchesSingleToken;
+      this.singleMatchedToken = singleMatchedToken;
+      this.noWayToComplete = noWayToComplete;
+      this.pendingToken = pendingToken;
+    }
+    private boolean isPendingTokenNonEmpty() {
+      return pendingToken != null && !pendingToken.text().isEmpty();
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorTestCase.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorTestCase.java
@@ -1,0 +1,63 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.cell.EditingTestCase;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprContainerMapper;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.ExprContainer;
+import jetbrains.jetpad.projectional.util.RootController;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Arrays;
+
+import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
+import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
+import static org.junit.Assert.assertEquals;
+
+class BaseHybridEditorTestCase extends EditingTestCase {
+  ExprContainer container = new ExprContainer();
+  ExprContainerMapper mapper = new ExprContainerMapper(container);
+  HybridSynchronizer<Expr> sync;
+  Cell targetCell;
+
+  private Registration registration;
+
+  @Before
+  public void init() {
+    registration = RootController.install(myCellContainer);
+    mapper.attachRoot();
+    myCellContainer.root.children().add(targetCell = mapper.getTarget());
+    CellActions.toFirstFocusable(mapper.getTarget()).run();
+    sync = mapper.hybridSync;
+  }
+
+  @After
+  public void dispose() {
+    mapper.detachRoot();
+    registration.remove();
+  }
+
+  void setTokens(Token... tokens) {
+    sync.setTokens(Arrays.asList(tokens));
+  }
+
+  void assertTokens(Token... tokens) {
+    assertEquals(Arrays.asList(tokens), sync.tokens());
+  }
+
+  void assertLastSeenText(String lastSeenText) {
+    assertEquals(lastSeenText, myEditableCellContainer.getLastSeenText());
+  }
+
+  void select(int index, boolean first) {
+    sync.tokenOperations().select(index, first ? FIRST : LAST).run();
+  }
+
+  void select(int index, int pos) {
+    sync.tokenOperations().select(index, pos).run();
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BasicHybridEditorTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BasicHybridEditorTest.java
@@ -17,12 +17,9 @@ package jetbrains.jetpad.hybrid;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Range;
-import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.cell.Cell;
-import jetbrains.jetpad.cell.EditingTestCase;
 import jetbrains.jetpad.cell.HorizontalCell;
 import jetbrains.jetpad.cell.TextCell;
-import jetbrains.jetpad.cell.action.CellActions;
 import jetbrains.jetpad.cell.completion.Completion;
 import jetbrains.jetpad.cell.message.MessageController;
 import jetbrains.jetpad.cell.position.Positions;
@@ -34,45 +31,17 @@ import jetbrains.jetpad.event.KeyEvent;
 import jetbrains.jetpad.event.KeyStrokeSpecs;
 import jetbrains.jetpad.event.ModifierKey;
 import jetbrains.jetpad.hybrid.parser.*;
-import jetbrains.jetpad.hybrid.testapp.mapper.ExprContainerMapper;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
 import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
 import jetbrains.jetpad.hybrid.testapp.model.*;
 import jetbrains.jetpad.hybrid.util.HybridWrapperRole;
 import jetbrains.jetpad.mapper.Mapper;
 import jetbrains.jetpad.model.composite.Composites;
-import jetbrains.jetpad.projectional.util.RootController;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
-
-import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
-import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
 import static org.junit.Assert.*;
 
-public class HybridEditorTest extends EditingTestCase {
-  private ExprContainer container = new ExprContainer();
-  private Registration registration;
-  private ExprContainerMapper mapper = new ExprContainerMapper(container);
-  private HybridSynchronizer<Expr> sync;
-  private Cell myTargetCell;
-
-  @Before
-  public void init() {
-    registration = RootController.install(myCellContainer);
-    mapper.attachRoot();
-    myCellContainer.root.children().add(myTargetCell = mapper.getTarget());
-    CellActions.toFirstFocusable(mapper.getTarget()).run();
-    sync = mapper.hybridSync;
-  }
-
-  @After
-  public void dispose() {
-    mapper.detachRoot();
-    registration.remove();
-  }
+public class BasicHybridEditorTest extends BaseHybridEditorTestCase {
 
   @Test
   public void simpleTyping() {
@@ -762,55 +731,6 @@ public class HybridEditorTest extends EditingTestCase {
     assertSelection(0, 2);
     assertSelected(0);
   }
-
-  @Test
-  public void copyPaste() {
-    setTokens(Tokens.ID, Tokens.PLUS);
-    select(0, true);
-
-    press(Key.RIGHT, ModifierKey.SHIFT);
-    press(KeyStrokeSpecs.COPY);
-    press(KeyStrokeSpecs.PASTE);
-
-    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
-  }
-
-  @Test
-  public void cut() {
-    setTokens(Tokens.ID, Tokens.PLUS);
-    select(0, true);
-
-    press(Key.RIGHT, ModifierKey.SHIFT);
-    press(KeyStrokeSpecs.CUT);
-
-    assertTokens(Tokens.PLUS);
-  }
-
-  @Test
-  public void cutPaste() {
-    setTokens(Tokens.ID, Tokens.PLUS);
-    select(0, true);
-
-    press(Key.RIGHT, ModifierKey.SHIFT);
-    press(KeyStrokeSpecs.CUT);
-    press(KeyStrokeSpecs.PASTE);
-    press(KeyStrokeSpecs.PASTE);
-
-    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
-  }
-
-  @Test
-  public void pasteToEmpty() {
-    setTokens(Tokens.ID);
-    select(0, true);
-    press(Key.RIGHT, ModifierKey.SHIFT);
-
-    press(KeyStrokeSpecs.CUT);
-    press(KeyStrokeSpecs.PASTE);
-
-    assertTokens(Tokens.ID);
-  }
-
   @Test
   public void clearAll() {
     setTokens(Tokens.ID, Tokens.ID);
@@ -836,7 +756,7 @@ public class HybridEditorTest extends EditingTestCase {
 
     del();
 
-    Cell tokenCell = myTargetCell.children().get(0);
+    Cell tokenCell = targetCell.children().get(0);
     assertFocused(tokenCell);
     assertTrue(Positions.isHomePosition(tokenCell));
     assertTokens(Tokens.ID);
@@ -851,7 +771,7 @@ public class HybridEditorTest extends EditingTestCase {
 
     del();
 
-    Cell tokenCell = myTargetCell.children().get(0);
+    Cell tokenCell = targetCell.children().get(0);
     assertFocused(tokenCell);
     assertTrue(Positions.isEndPosition(tokenCell));
     assertTokens(Tokens.ID);
@@ -859,30 +779,30 @@ public class HybridEditorTest extends EditingTestCase {
 
   @Test
   public void statePersistence() {
-    CellStateHandler handler = myTargetCell.get(CellStateHandler.PROPERTY);
+    CellStateHandler handler = targetCell.get(CellStateHandler.PROPERTY);
 
     setTokens(Tokens.ID, Tokens.ID, Tokens.ID);
-    CellState state = handler.saveState(myTargetCell);
+    CellState state = handler.saveState(targetCell);
 
     select(1, true);
     type(" id");
 
-    handler.restoreState(myTargetCell, state);
+    handler.restoreState(targetCell, state);
 
     assertTokens(Tokens.ID, Tokens.ID, Tokens.ID);
   }
 
   @Test
   public void valueTokenStatePersistence() {
-    CellStateHandler handler = myTargetCell.get(CellStateHandler.PROPERTY);
+    CellStateHandler handler = targetCell.get(CellStateHandler.PROPERTY);
 
     ValueExpr valExpr = new ValueExpr();
     setTokens(new ValueToken(valExpr, new ValueExprCloner()), Tokens.ID);
 
-    CellState state = handler.saveState(myTargetCell);
+    CellState state = handler.saveState(targetCell);
     valExpr.val.set("z");
 
-    handler.restoreState(myTargetCell, state);
+    handler.restoreState(targetCell, state);
 
     ValueToken newVal = (ValueToken) sync.tokens().get(0);
     assertNull(((ValueExpr) newVal.value()).val.get());
@@ -1042,22 +962,6 @@ public class HybridEditorTest extends EditingTestCase {
 
   private ValueToken createComplexToken() {
     return new ValueToken(new ComplexValueExpr(), new ComplexValueCloner());
-  }
-
-  private void assertTokens(Token... tokens) {
-    assertEquals(Arrays.asList(tokens), sync.tokens());
-  }
-
-  private void setTokens(Token... tokens) {
-    sync.setTokens(Arrays.asList(tokens));
-  }
-
-  private void select(int index, boolean first) {
-    sync.tokenOperations().select(index, first ? FIRST : LAST).run();
-  }
-
-  private void select(int index, int pos) {
-    sync.tokenOperations().select(index, pos).run();
   }
 
   private Cell tokenCell(int index) {

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorCopyPasteTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorCopyPasteTest.java
@@ -1,0 +1,124 @@
+package jetbrains.jetpad.hybrid;
+
+import com.google.common.collect.ImmutableList;
+import jetbrains.jetpad.cell.TextCell;
+import jetbrains.jetpad.event.Key;
+import jetbrains.jetpad.event.KeyStrokeSpecs;
+import jetbrains.jetpad.event.ModifierKey;
+import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.values.Color;
+import org.junit.Test;
+
+import static jetbrains.jetpad.hybrid.TokensUtil.*;
+import static org.junit.Assert.assertEquals;
+
+public class HybridEditorCopyPasteTest extends BaseHybridEditorTestCase {
+  @Test
+  public void copyPasteToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    press(KeyStrokeSpecs.COPY);
+    assertLastSeenText("id");
+
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
+  }
+
+  @Test
+  public void cutToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    press(KeyStrokeSpecs.CUT);
+    assertLastSeenText("id");
+
+    assertTokens(Tokens.PLUS);
+
+  }
+
+  @Test
+  public void cutPasteToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    press(KeyStrokeSpecs.CUT);
+    assertLastSeenText("id");
+
+    press(KeyStrokeSpecs.PASTE);
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
+  }
+
+  @Test
+  public void pasteTokenToEmpty() {
+    setTokens(Tokens.ID);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    press(KeyStrokeSpecs.CUT);
+    assertLastSeenText("id");
+
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID);
+  }
+
+  @Test
+  public void copySimpleExpr() {
+    type("10+25");
+    selectLeft(3);
+    press(KeyStrokeSpecs.COPY);
+    assertLastSeenText("10 + 25");
+  }
+
+  @Test
+  public void pasteSimpleExprAsText() {
+    paste("10+25");
+    assertTokens(integer(10), Tokens.PLUS, integer(25));
+    TextCell text = (TextCell) myCellContainer.focusedCell.get();
+    assertEquals("25", text.text().get());
+    assertEquals(2, (int) text.caretPosition().get());
+  }
+
+  @Test
+  public void pasteIncorrectText() {
+    paste("10+bad");
+    assertTokens(integer(10), Tokens.PLUS, error("bad"));
+    TextCell text = (TextCell) myCellContainer.focusedCell.get();
+    assertEquals("bad", text.text().get());
+    assertEquals(3, (int) text.caretPosition().get());
+    assertEquals(Color.RED, text.textColor().get());
+  }
+
+  @Test
+  public void pasteToNonempty() {
+    type("id");
+    paste("+ 10");
+    assertTokens(Tokens.ID, Tokens.PLUS, integer(10));
+  }
+
+  @Test
+  public void copyStringLiteralWithOtherTokens() {
+    String text = "10+'text 1";   // Closing quote autocompletes
+    type(text);
+    right();
+    selectLeft(text.length() + 1);
+    press(KeyStrokeSpecs.COPY);
+    assertLastSeenText("10 + 'text 1'");
+  }
+
+  @Test
+  public void pasteStringLiteralWithOtherTokens() {
+    paste("\"text 1\" + 10");
+    assertTokensEqual(ImmutableList.of(doubleQtd("text 1"), Tokens.PLUS, integer(10)), sync.tokens());
+  }
+
+  private void selectLeft(int steps) {
+    for (int i = 0; i < steps; i++) {
+      press(Key.LEFT, ModifierKey.SHIFT);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+import static jetbrains.jetpad.hybrid.TokensUtil.*;
+import static jetbrains.jetpad.hybrid.testapp.mapper.Tokens.*;
+import static org.junit.Assert.assertTrue;
+
+public class TokenizerTest {
+  private Tokenizer<Expr> tokenizer = new Tokenizer<>(new ExprHybridEditorSpec());
+
+  @Test
+  public void oneToken() {
+    List<Token> tokens = tokenizer.tokenize("!");
+    assertTokensEqual(of(FACTORIAL), tokens);
+  }
+
+  @Test
+  public void emptyInput() {
+    List<Token> tokens = tokenizer.tokenize("");
+    assertTrue(tokens.isEmpty());
+  }
+
+  @Test
+  public void blankInput() {
+    List<Token> tokens = tokenizer.tokenize(" \t ");
+    assertTrue(tokens.isEmpty());
+  }
+
+  @Test
+  public void simpleExpression() {
+    List<Token> tokens = tokenizer.tokenize("1+2");
+    assertTokensEqual(of(integer(1), PLUS, integer(2)), tokens);
+  }
+
+  @Test
+  public void simpleExpressionWithWhitespaces() {
+    List<Token> tokens = tokenizer.tokenize("  1\t * 2");
+    assertTokensEqual(of(integer(1), MUL, integer(2)), tokens);
+  }
+
+  @Test
+  public void incrementAndPlus() {
+    List<Token> tokens = tokenizer.tokenize("+++");
+    assertTokensEqual(of(INCREMENT, PLUS), tokens);
+  }
+
+  @Test
+  public void valueTokens() {
+    List<Token> tokens = tokenizer.tokenize("value * aaaa + posValue");
+    assertTokensEqual(of(value(), MUL, complex(), PLUS, pos()), tokens);
+  }
+
+  @Test
+  public void emptyStrings() {
+    List<Token> tokens = tokenizer.tokenize("\"\"\"\" '' ''");
+    assertTokensEqual(of(doubleQtd(""), doubleQtd(""), singleQtd(""), singleQtd("")), tokens);
+  }
+
+  @Test
+  public void stringLiterals() {
+    final String strBody = "These items must not be tokenized: 10 + 17! * id.value";
+    List<Token> tokens = tokenizer.tokenize("id + \"" + strBody + "\"'" + strBody + "'");
+    assertTokensEqual(of(ID, PLUS, doubleQtd(strBody), singleQtd(strBody)), tokens);
+  }
+
+  @Test
+  public void nestedQuotesOfDifferentKind() {
+    List<Token> tokens = tokenizer.tokenize("\"'\"'\"'");
+    assertTokensEqual(of(doubleQtd("'"), singleQtd("\"")), tokens);
+  }
+
+  @Test
+  public void longCorrectExpression() {
+    List<Token> tokens = tokenizer.tokenize("\t( 10) * 5! + id.value ++ + '\"text 1\"' + \"text 2\"");
+    assertTokensEqual(of(LP, integer(10), RP, MUL, integer(5), FACTORIAL, PLUS, ID, DOT, value(), INCREMENT, PLUS,
+        singleQtd("\"text 1\""), PLUS, doubleQtd("text 2")),
+        tokens);
+  }
+
+  @Test
+  public void oneIncorrect() {
+    List<Token> tokens = tokenizer.tokenize("\tbad  ");
+    assertTokensEqual(of(error("bad")), tokens);
+  }
+
+  @Test
+  public void severalIncorrect() {
+    List<Token> tokens = tokenizer.tokenize(" bad \tinput");
+    assertTokensEqual(of(error("bad"), error("input")), tokens);
+  }
+
+  @Test
+  public void correctAndIncorrect() {
+    List<Token> tokens = tokenizer.tokenize("value bad + 7 ^ 5");
+    assertTokensEqual(of(value(), error("bad"), PLUS, integer(7), error("^"), integer(5)), tokens);
+  }
+
+  @Test
+  public void recoverOnlyAfterSpace() {
+    List<Token> tokens = tokenizer.tokenize("bad+ bad +");
+    assertTokensEqual(of(error("bad+"), error("bad"), PLUS), tokens);
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
@@ -1,0 +1,85 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.ErrorToken;
+import jetbrains.jetpad.hybrid.parser.IntValueToken;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.mapper.ValueExprTextGen;
+import jetbrains.jetpad.hybrid.testapp.mapper.ValueExprCloner;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+class TokensUtil {
+  private TokensUtil() {
+  }
+
+  static Token integer(int val) {
+    return new IntValueToken(val);
+  }
+
+  static Token singleQtd(String body) {
+    return new ValueToken(new StringExpr("'", body), new ValueExprCloner(), new ValueExprTextGen());
+  }
+
+  static Token doubleQtd(String body) {
+    return new ValueToken(new StringExpr("\"", body), new ValueExprCloner(), new ValueExprTextGen());
+  }
+
+  static Token complex() {
+    return new ValueToken(new ComplexValueExpr(), new ValueExprCloner());
+  }
+
+  static Token pos() {
+    return new ValueToken(new PosValueExpr(), new ValueExprCloner());
+  }
+
+  static Token value() {
+    return new ValueToken(new ValueExpr(), new ValueExprCloner());
+  }
+
+  static Token async() {
+    return new ValueToken(new AsyncValueExpr(), new ValueExprCloner());
+  }
+  static Token error(String text) {
+    return new ErrorToken(text);
+  }
+
+  static void assertTokensEqual(List<Token> expected, List<Token> actual) {
+    assertEquals(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+      Token expectedToken = expected.get(i);
+      Token actualToken = actual.get(i);
+      if (expectedToken instanceof ValueToken) {
+        assertTrue(actualToken instanceof ValueToken);
+        assertValueTokensEqual((ValueToken) expectedToken, (ValueToken) actualToken);
+      } else if (expectedToken instanceof ErrorToken) {
+        assertTrue(actualToken instanceof ErrorToken);
+        assertEquals(expectedToken.toString(), actualToken.toString());
+      } else {
+        assertEquals(expectedToken, actualToken);
+      }
+    }
+  }
+
+  private static void assertValueTokensEqual(ValueToken expected, ValueToken actual) {
+    Object expectedValue = expected.value();
+    Object actualValue = actual.value();
+    if (expectedValue instanceof ValueExpr) {
+      assertTrue(actualValue instanceof ValueExpr);
+      assertEquals(((ValueExpr) expectedValue).val.get(), ((ValueExpr) actualValue).val.get());
+    } else if (expectedValue instanceof ComplexValueExpr) {
+      assertTrue(actualValue instanceof ComplexValueExpr);
+    } else if (expectedValue instanceof PosValueExpr) {
+      assertTrue(actualValue instanceof PosValueExpr);
+    } else if (expectedValue instanceof StringExpr) {
+      assertTrue(actualValue instanceof StringExpr);
+      assertEquals(actualValue.toString(), expectedValue.toString());
+    } else {
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
@@ -35,6 +35,9 @@ class ExprMapperFactory implements MapperFactory<Object,Cell> {
     if (source instanceof ComplexValueExpr) {
       return new ComplexValueExprMapper((ComplexValueExpr) source);
     }
+    if (source instanceof StringExpr) {
+      return new StringExprMapper((StringExpr) source);
+    }
     throw new IllegalArgumentException("Unknown source: " + source);
   }
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/StringExprMapper.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/StringExprMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.cell.HorizontalCell;
+import jetbrains.jetpad.cell.TextCell;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.cell.text.TextEditing;
+import jetbrains.jetpad.hybrid.testapp.model.StringExpr;
+import jetbrains.jetpad.mapper.Mapper;
+import jetbrains.jetpad.mapper.Synchronizers;
+import jetbrains.jetpad.projectional.cell.ProjectionalSynchronizers;
+
+import static jetbrains.jetpad.cell.util.CellFactory.label;
+import static jetbrains.jetpad.cell.util.CellFactory.to;
+
+class StringExprMapper extends Mapper<StringExpr, StringExprMapper.StringExprCell> {
+  StringExprMapper(StringExpr source) {
+    super(source, new StringExprCell(source.quote.get()));
+  }
+
+  @Override
+  protected void registerSynchronizers(SynchronizersConfiguration conf) {
+    super.registerSynchronizers(conf);
+    conf.add(Synchronizers.forPropsTwoWay(getSource().body, getTarget().body.text()));
+  }
+
+  static class StringExprCell extends HorizontalCell {
+    private final TextCell body = new TextCell();
+
+    private StringExprCell(String quote) {
+      to(
+          this,
+          label(quote, true, false),
+          body,
+          label(quote, false, true)
+      );
+      set(ProjectionalSynchronizers.ON_CREATE, CellActions.toFirstFocusable(body));
+      body.addTrait(TextEditing.textEditing());
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprCloner.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprCloner.java
@@ -1,0 +1,33 @@
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+public class ValueExprCloner implements ValueToken.ValueCloner<Expr> {
+  @Override
+  public Expr clone(Expr val) {
+    if (val instanceof ValueExpr) {
+      ValueExpr result = new ValueExpr();
+      result.val.set(((ValueExpr) val).val.get());
+      return result;
+    }
+
+    if (val instanceof ComplexValueExpr) {
+      return new ComplexValueExpr();
+    }
+
+    if (val instanceof PosValueExpr) {
+      return new PosValueExpr();
+    }
+
+    if (val instanceof AsyncValueExpr) {
+      return new AsyncValueExpr();
+    }
+
+    if (val instanceof StringExpr) {
+      return new StringExpr((StringExpr) val);
+    }
+
+    throw new IllegalArgumentException(val.toString());
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprTextGen.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprTextGen.java
@@ -1,0 +1,15 @@
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+public class ValueExprTextGen implements ValueToken.ValueTextGen<Expr> {
+  @Override
+  public String toText(Expr val) {
+    if (val instanceof StringExpr) {
+      return val.toString();
+    }
+
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/StringExpr.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/StringExpr.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.model;
+
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ReadOnlyProperty;
+import jetbrains.jetpad.model.property.ValueProperty;
+
+public class StringExpr extends Expr {
+  public final ReadOnlyProperty<String> quote;
+  public final Property<String> body = new ValueProperty<>("");
+
+  public StringExpr(String quote) {
+    this.quote = new ReadOnlyProperty<>(new ValueProperty<>(quote));
+  }
+
+  public StringExpr(String quote, String body) {
+    this(quote);
+    this.body.set(body);
+  }
+
+  public StringExpr(StringExpr toCopy) {
+    this(toCopy.quote.get());
+    this.body.set(toCopy.body.get());
+  }
+
+  @Override
+  public String toString() {
+    return quote.get() + body.get() + quote.get();
+  }
+}


### PR DESCRIPTION
Implementation notes:

`ByBoundsCompletionItem` allows completing the whole string literals, from opening quote to closing one. I expect strings editing to be backed by two completion items: Simple and ByBounds; first will complete single quote input (when you just type `"`), and second will work when you paste quoted string. However, tokenizing is not only useful application of `ByBoundsCompletionItem`: suppose you have typed a string without opening quote (`abc"`) — this won't be completed; then you position a cursor to the string beginning and type opening quote — and ByBounds completes the whole string (`"abc"`).

`Tokenizer` tokenizes some string against completions provided by `HybridEditorSpec`. Algorithm tries to find the longest single-match completions in input. This class is not a part of public API because it may change soon: further copypaste implementation will require adding more features and extension points to this class.

`ClipboardContent` implementation in `HybridSynchronizer` checks tokens against `text()` method support by catching `UnsupportedOpertationException`. This is not the best way; better would be checking something like `HybridEditorSpec.supportsToText()`, but this interface is public API which discourages adding new methods unless it's Java 8. When we migrate to it, I will rewrite this part.

Test application is added string literals and copypaste support, please try. Strings editing may seem not absolutely smooth; it will improve as we develop this feature.
