### PR TITLE
Implemented a textual copypaste in hybrid editor

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
@@ -240,6 +240,7 @@ public abstract class Cell implements NavComposite<Cell>, HasVisibility, HasFocu
     newTraits[0] = trait;
     System.arraycopy(myCellTraits, 0, newTraits, 1, myCellTraits.length);
     myCellTraits = newTraits;
+    trait.onAdd(this);
     r.run();
     return new Registration() {
       @Override
@@ -251,6 +252,7 @@ public abstract class Cell implements NavComposite<Cell>, HasVisibility, HasFocu
         System.arraycopy(myCellTraits, index + 1, newTraits, index, myCellTraits.length - index - 1);
         myCellTraits = newTraits;
         r.run();
+        trait.onRemove(Cell.this);
       }
     };
   }

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditing.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditing.java
@@ -41,6 +41,7 @@ public class TextEditing {
   public static final CellTraitPropertySpec<Function<String, Runnable>> EXPAND_LEFT = new CellTraitPropertySpec<>("expandLeft", expansionProvider(Side.LEFT));
   public static final CellTraitPropertySpec<Function<String, Runnable>> EXPAND_RIGHT = new CellTraitPropertySpec<>("expandRight", expansionProvider(Side.RIGHT));
   public static final CellTraitPropertySpec<Supplier<Boolean>> AFTER_TYPE = new CellTraitPropertySpec<>("afterType");
+  public static final CellTraitPropertySpec<Supplier<Boolean>> AFTER_PASTE = new CellTraitPropertySpec<>("afterPaste");
 
   public static final CellTraitPropertySpec<Boolean> EAGER_COMPLETION = new CellTraitPropertySpec<>("eagerCompletion", false);
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -191,6 +191,7 @@ public class TextEditingTrait extends TextNavigationTrait {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     clearSelection(editor);
     pasteText(editor, newText.toString());
+    onAfterPaste(editor);
     event.consume();
   }
 
@@ -238,6 +239,14 @@ public class TextEditingTrait extends TextNavigationTrait {
     Supplier<Boolean> afterType = ((CellTextEditor) editor).getCell().get(TextEditing.AFTER_TYPE);
     if (afterType != null) {
       return afterType.get();
+    }
+    return false;
+  }
+
+  protected boolean onAfterPaste(TextEditor editor) {
+    Supplier<Boolean> afterPaste = ((CellTextEditor) editor).getCell().get(TextEditing.AFTER_PASTE);
+    if (afterPaste != null) {
+      return afterPaste.get();
     }
     return false;
   }

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
@@ -51,6 +51,11 @@ class ValidTextEditingTrait extends TextEditingTrait {
   }
 
   @Override
+  public void onAdd(Cell cell) {
+    validate(cell);
+  }
+
+  @Override
   public void onKeyPressed(Cell cell, KeyEvent event) {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     if (event.is(Key.ENTER) && !TextEditing.isEmpty(editor) && !isValid(editor)) {
@@ -74,11 +79,14 @@ class ValidTextEditingTrait extends TextEditingTrait {
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> e) {
     if (prop == TextCell.TEXT) {
-      CellTextEditor editor = TextEditing.cellTextEditor(cell);
-      MessageController.setBroken(cell, isValid(editor) ? null : "Cannot resolve '" + TextEditing.text(editor) + '\'');
+      validate(cell);
     }
-
     super.onPropertyChanged(cell, prop, e);
+  }
+
+  private void validate(Cell cell) {
+    CellTextEditor editor = TextEditing.cellTextEditor(cell);
+    MessageController.setBroken(cell, isValid(editor) ? null : "Cannot resolve '" + TextEditing.text(editor) + '\'');
   }
 
   @Override

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/CellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/CellTrait.java
@@ -33,6 +33,12 @@ public abstract class CellTrait {
   public static final Object NULL = new Object();
   public static final CellTrait[] EMPTY_ARRAY = new CellTrait[0];
 
+  public void onAdd(Cell cell) {
+  }
+
+  public void onRemove(Cell cell) {
+  }
+
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {
   }
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
@@ -26,6 +26,20 @@ public abstract class CompositeCellTrait extends CellTrait {
   protected abstract CellTrait[] getBaseTraits(Cell cell);
 
   @Override
+  public void onAdd(Cell cell) {
+    for (CellTrait t : getBaseTraits(cell)) {
+      t.onAdd(cell);
+    }
+  }
+
+  @Override
+  public void onRemove(Cell cell) {
+    for (CellTrait t : getBaseTraits(cell)) {
+      t.onRemove(cell);
+    }
+  }
+
+  @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {
     for (CellTrait t : getBaseTraits(cell)) {
       t.onPropertyChanged(cell, prop, event);

--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/DerivedCellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/DerivedCellTrait.java
@@ -22,10 +22,18 @@ import jetbrains.jetpad.cell.event.FocusEvent;
 import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
-import javax.annotation.Nonnull;
-
 public abstract class DerivedCellTrait extends CellTrait {
   protected abstract CellTrait getBase(Cell cell);
+
+  @Override
+  public void onAdd(Cell cell) {
+    getBase(cell).onAdd(cell);
+  }
+
+  @Override
+  public void onRemove(Cell cell) {
+    getBase(cell).onRemove(cell);
+  }
 
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> event) {

--- a/cell/src/test/java/jetbrains/jetpad/cell/EditableCellContainer.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/EditableCellContainer.java
@@ -69,6 +69,18 @@ public class EditableCellContainer {
     return event;
   }
 
+  public ClipboardContent cut() {
+    CopyCutEvent e = new CopyCutEvent(true);
+    myViewContainer.cut(e);
+    return e.getResult();
+  }
+
+  public ClipboardContent copy() {
+    CopyCutEvent e = new CopyCutEvent(false);
+    myViewContainer.copy(e);
+    return e.getResult();
+  }
+
   public void paste(String text) {
     container.paste(text);
   }

--- a/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
@@ -55,6 +55,14 @@ public abstract class EditingTestCase extends BaseTestCase {
     return myEditableCellContainer.press(ks);
   }
 
+  protected ClipboardContent cut() {
+    return myEditableCellContainer.cut();
+  }
+
+  protected ClipboardContent copy() {
+    return myEditableCellContainer.copy();
+  }
+
   protected void paste(String text) {
     myEditableCellContainer.paste(text);
   }

--- a/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.completion;
+
+public abstract class ByBoundsCompletionItem extends BaseCompletionItem {
+  private final String myPrefix;
+  private final String mySuffix;
+  private final String myVisibleText;
+
+  protected ByBoundsCompletionItem(String prefix, String suffix) {
+    myPrefix = prefix;
+    mySuffix = suffix;
+    myVisibleText = prefix + "..." + suffix;
+  }
+
+  @Override
+  public String visibleText(String text) {
+    return myVisibleText;
+  }
+
+  @Override
+  public boolean isStrictMatchPrefix(String text) {
+    return myPrefix.startsWith(text) || isPrefixedButNotSuffixed(text);
+  }
+
+  @Override
+  public boolean isMatch(String text) {
+    return isPrefixedAndSuffixed(text);
+  }
+
+  private boolean isPrefixedButNotSuffixed(String text) {
+    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == -1;
+  }
+
+  private boolean isPrefixedAndSuffixed(String text) {
+    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == (text.length() - mySuffix.length());
+  }
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -106,6 +106,15 @@ class TextTokenCell extends TextCell {
           };
         }
 
+        if (spec == TextEditing.AFTER_PASTE) {
+          return new Supplier<Boolean>() {
+            @Override
+            public Boolean get() {
+              return tokenOperations(cell).afterPaste(TextTokenCell.this);
+            }
+          };
+        }
+
         return super.get(cell, spec);
       }
 

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
@@ -264,4 +264,19 @@ class TokenOperations<SourceT> {
     return false;
   }
 
+  boolean afterPaste(TextCell textView) {
+    Tokenizer<SourceT> tokenizer = new Tokenizer<>(mySync.editorSpec());
+    List<Token> newTokens = tokenizer.tokenize(textView.text().get());
+    int index;
+    if (!tokens().isEmpty()) {
+      index = tokenViews().indexOf(textView);
+      tokens().remove(index);
+    } else {
+      index = 0;
+    }
+    tokens().addAll(index, newTokens);
+    mySync.tokenListEditor().updateToPrintedTokens();
+    select(index + newTokens.size() - 1, LAST).run();
+    return true;
+  }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Function;
+import jetbrains.jetpad.base.Value;
+import jetbrains.jetpad.cell.completion.CompletionItems;
+import jetbrains.jetpad.completion.CompletionItem;
+import jetbrains.jetpad.completion.CompletionParameters;
+import jetbrains.jetpad.hybrid.parser.ErrorToken;
+import jetbrains.jetpad.hybrid.parser.Token;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+
+class Tokenizer<SourceT> {
+  private final HybridEditorSpec<SourceT> mySpec;
+
+  Tokenizer(HybridEditorSpec<SourceT> spec) {
+    mySpec = spec;
+  }
+
+  List<Token> tokenize(String input) {
+    TokensCollector tc = new TokensCollector();
+    for (char currentChar : input.toCharArray()) {
+      tc.append(currentChar);
+    }
+    tc.collectLastToken();
+    return tc.tokens;
+  }
+
+  private class TokensCollector {
+    private final TextMatcher textMatcher = new TextMatcher();
+    private final StringBuilder currentTokenCandidate = new StringBuilder();
+    private TextMatchResult currentMatchResult = pending("");
+    private final List<Token> tokens = new ArrayList<>();
+
+    private void append(char ch) {
+      if (CharMatcher.whitespace().matches(ch)) {
+        if (currentTokenCandidate.length() == 0) {
+           return;
+        }
+        if (currentMatchResult.noWayToComplete) {
+          tokens.add(currentMatchResult.pendingToken);
+          clear();
+          return;
+        }
+      }
+
+      TextMatchResult prevMatchResult = currentMatchResult;
+      currentTokenCandidate.append(ch);
+      updateMatchResult();
+      if (currentMatchResult.noWayToComplete && prevMatchResult.matchesSingleToken) {
+        tokens.add(prevMatchResult.singleMatchedToken);
+        clear();
+        append(ch);
+      }
+    }
+
+    private void collectLastToken() {
+      if (currentMatchResult.matchesSingleToken) {
+        tokens.add(currentMatchResult.singleMatchedToken);
+      } else if (currentMatchResult.isPendingTokenNonEmpty()) {
+        tokens.add(currentMatchResult.pendingToken);
+      }
+    }
+
+    private void clear() {
+      currentTokenCandidate.setLength(0);
+      currentMatchResult = pending("");
+    }
+
+    private void updateMatchResult() {
+      currentMatchResult = textMatcher.match(currentTokenCandidate.toString());
+    }
+  }
+
+  private class TextMatcher {
+    private final Value<Token> tokenHolder = new Value<>();
+    private final CompletionItems completionItems = new CompletionItems(
+        mySpec.getTokenCompletion(new Function<Token, Runnable>() {
+          @Nullable
+          @Override
+          public Runnable apply(@Nullable final Token token) {
+            return new Runnable() {
+              @Override
+              public void run() {
+                tokenHolder.set(token);
+              }
+            };
+          }
+        }).get(CompletionParameters.EMPTY));
+
+    private TextMatchResult match(String text) {
+      List<CompletionItem> basicMatches = completionItems.matches(text);
+      if (basicMatches.size() == 1) {
+        basicMatches.iterator().next().complete(text).run();
+        return singleMatched(tokenHolder.get());
+      } else {
+        boolean noWayToComplete = basicMatches.isEmpty() && completionItems.prefixedBy(text).isEmpty();
+        if (noWayToComplete) {
+          return error(text);
+        } else {
+          return pending(text);
+        }
+      }
+    }
+  }
+
+  private static TextMatchResult singleMatched(Token token) {
+    return new TextMatchResult(true, token, false, null);
+  }
+
+  private static TextMatchResult error(String text) {
+    return new TextMatchResult(false, null, true, new ErrorToken(text));
+  }
+
+  private static TextMatchResult pending(String text) {
+    return new TextMatchResult(false, null, false, new ErrorToken(text));
+  }
+
+  private static class TextMatchResult {
+    private final boolean matchesSingleToken;
+    private final Token singleMatchedToken;
+    private final boolean noWayToComplete;
+    private final ErrorToken pendingToken;
+    private TextMatchResult(boolean matchesSingleToken, Token singleMatchedToken, boolean noWayToComplete, ErrorToken pendingToken) {
+      this.matchesSingleToken = matchesSingleToken;
+      this.singleMatchedToken = singleMatchedToken;
+      this.noWayToComplete = noWayToComplete;
+      this.pendingToken = pendingToken;
+    }
+    private boolean isPendingTokenNonEmpty() {
+      return pendingToken != null && !pendingToken.text().isEmpty();
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTestCase.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTestCase.java
@@ -1,0 +1,59 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.cell.EditingTestCase;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprContainerMapper;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.ExprContainer;
+import jetbrains.jetpad.projectional.util.RootController;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Arrays;
+
+import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
+import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
+import static org.junit.Assert.assertEquals;
+
+class BaseHybridEditorEditingTestCase extends EditingTestCase {
+  ExprContainer container = new ExprContainer();
+  ExprContainerMapper mapper = new ExprContainerMapper(container);
+  HybridSynchronizer<Expr> sync;
+  Cell targetCell;
+
+  private Registration registration;
+
+  @Before
+  public void init() {
+    registration = RootController.install(myCellContainer);
+    mapper.attachRoot();
+    myCellContainer.root.children().add(targetCell = mapper.getTarget());
+    CellActions.toFirstFocusable(mapper.getTarget()).run();
+    sync = mapper.hybridSync;
+  }
+
+  @After
+  public void dispose() {
+    mapper.detachRoot();
+    registration.remove();
+  }
+
+  void setTokens(Token... tokens) {
+    sync.setTokens(Arrays.asList(tokens));
+  }
+
+  void assertTokens(Token... tokens) {
+    assertEquals(Arrays.asList(tokens), sync.tokens());
+  }
+
+  void select(int index, boolean first) {
+    sync.tokenOperations().select(index, first ? FIRST : LAST).run();
+  }
+
+  void select(int index, int pos) {
+    sync.tokenOperations().select(index, pos).run();
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorCopyPasteTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorCopyPasteTest.java
@@ -1,0 +1,125 @@
+package jetbrains.jetpad.hybrid;
+
+import com.google.common.collect.ImmutableList;
+import jetbrains.jetpad.cell.TextCell;
+import jetbrains.jetpad.event.ClipboardContent;
+import jetbrains.jetpad.event.Key;
+import jetbrains.jetpad.event.KeyStrokeSpecs;
+import jetbrains.jetpad.event.ModifierKey;
+import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.values.Color;
+import org.junit.Test;
+
+import static jetbrains.jetpad.hybrid.TokensUtil.*;
+import static org.junit.Assert.assertEquals;
+
+public class HybridEditorCopyPasteTest extends BaseHybridEditorEditingTestCase {
+  @Test
+  public void copyPasteToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    ClipboardContent clipboardContent = copy();
+    assertEquals("id", clipboardContent.toString());
+
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
+  }
+
+  @Test
+  public void cutToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    ClipboardContent clipboardContent = cut();
+    assertEquals("id", clipboardContent.toString());
+
+    assertTokens(Tokens.PLUS);
+
+  }
+
+  @Test
+  public void cutPasteToken() {
+    setTokens(Tokens.ID, Tokens.PLUS);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    ClipboardContent clipboardContent = cut();
+    assertEquals("id", clipboardContent.toString());
+
+    press(KeyStrokeSpecs.PASTE);
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID, Tokens.ID, Tokens.PLUS);
+  }
+
+  @Test
+  public void pasteTokenToEmpty() {
+    setTokens(Tokens.ID);
+    select(0, true);
+    press(Key.RIGHT, ModifierKey.SHIFT);
+
+    ClipboardContent clipboardContent = cut();
+    assertEquals("id", clipboardContent.toString());
+
+    press(KeyStrokeSpecs.PASTE);
+    assertTokens(Tokens.ID);
+  }
+
+  @Test
+  public void copySimpleExpr() {
+    type("10+25");
+    selectLeft(3);
+    ClipboardContent clipboardContent = copy();
+    assertEquals("10 + 25", clipboardContent.toString());
+  }
+
+  @Test
+  public void pasteSimpleExprAsText() {
+    paste("10+25");
+    assertTokens(integer(10), Tokens.PLUS, integer(25));
+    TextCell text = (TextCell) myCellContainer.focusedCell.get();
+    assertEquals("25", text.text().get());
+    assertEquals(2, (int) text.caretPosition().get());
+  }
+
+  @Test
+  public void pasteIncorrectText() {
+    paste("10+bad");
+    assertTokens(integer(10), Tokens.PLUS, error("bad"));
+    TextCell text = (TextCell) myCellContainer.focusedCell.get();
+    assertEquals("bad", text.text().get());
+    assertEquals(3, (int) text.caretPosition().get());
+    assertEquals(Color.RED, text.textColor().get());
+  }
+
+  @Test
+  public void pasteToNonempty() {
+    type("id");
+    paste("+ 10");
+    assertTokens(Tokens.ID, Tokens.PLUS, integer(10));
+  }
+
+  @Test
+  public void copyStringLiteralWithOtherTokens() {
+    String text = "10+'text 1";   // Closing quote autocompletes
+    type(text);
+    right();
+    selectLeft(text.length() + 1);
+    ClipboardContent clipboardContent = copy();
+    assertEquals("10 + 'text 1'", clipboardContent.toString());
+  }
+
+  @Test
+  public void pasteStringLiteralWithOtherTokens() {
+    paste("\"text 1\" + 10");
+    assertTokensEqual(ImmutableList.of(doubleQtd("text 1"), Tokens.PLUS, integer(10)), sync.tokens());
+  }
+
+  private void selectLeft(int steps) {
+    for (int i = 0; i < steps; i++) {
+      press(Key.LEFT, ModifierKey.SHIFT);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+import static jetbrains.jetpad.hybrid.TokensUtil.*;
+import static jetbrains.jetpad.hybrid.testapp.mapper.Tokens.*;
+import static org.junit.Assert.assertTrue;
+
+public class TokenizerTest {
+  private Tokenizer<Expr> tokenizer = new Tokenizer<>(new ExprHybridEditorSpec());
+
+  @Test
+  public void oneToken() {
+    List<Token> tokens = tokenizer.tokenize("!");
+    assertTokensEqual(of(FACTORIAL), tokens);
+  }
+
+  @Test
+  public void emptyInput() {
+    List<Token> tokens = tokenizer.tokenize("");
+    assertTrue(tokens.isEmpty());
+  }
+
+  @Test
+  public void blankInput() {
+    List<Token> tokens = tokenizer.tokenize(" \t ");
+    assertTrue(tokens.isEmpty());
+  }
+
+  @Test
+  public void simpleExpression() {
+    List<Token> tokens = tokenizer.tokenize("1+2");
+    assertTokensEqual(of(integer(1), PLUS, integer(2)), tokens);
+  }
+
+  @Test
+  public void simpleExpressionWithWhitespaces() {
+    List<Token> tokens = tokenizer.tokenize("  1\t * 2");
+    assertTokensEqual(of(integer(1), MUL, integer(2)), tokens);
+  }
+
+  @Test
+  public void incrementAndPlus() {
+    List<Token> tokens = tokenizer.tokenize("+++");
+    assertTokensEqual(of(INCREMENT, PLUS), tokens);
+  }
+
+  @Test
+  public void valueTokens() {
+    List<Token> tokens = tokenizer.tokenize("value * aaaa + posValue");
+    assertTokensEqual(of(value(), MUL, complex(), PLUS, pos()), tokens);
+  }
+
+  @Test
+  public void emptyStrings() {
+    List<Token> tokens = tokenizer.tokenize("\"\"\"\" '' ''");
+    assertTokensEqual(of(doubleQtd(""), doubleQtd(""), singleQtd(""), singleQtd("")), tokens);
+  }
+
+  @Test
+  public void stringLiterals() {
+    final String strBody = "These items must not be tokenized: 10 + 17! * id.value";
+    List<Token> tokens = tokenizer.tokenize("id + \"" + strBody + "\"'" + strBody + "'");
+    assertTokensEqual(of(ID, PLUS, doubleQtd(strBody), singleQtd(strBody)), tokens);
+  }
+
+  @Test
+  public void nestedQuotesOfDifferentKind() {
+    List<Token> tokens = tokenizer.tokenize("\"'\"'\"'");
+    assertTokensEqual(of(doubleQtd("'"), singleQtd("\"")), tokens);
+  }
+
+  @Test
+  public void longCorrectExpression() {
+    List<Token> tokens = tokenizer.tokenize("\t( 10) * 5! + id.value ++ + '\"text 1\"' + \"text 2\"");
+    assertTokensEqual(of(LP, integer(10), RP, MUL, integer(5), FACTORIAL, PLUS, ID, DOT, value(), INCREMENT, PLUS,
+        singleQtd("\"text 1\""), PLUS, doubleQtd("text 2")),
+        tokens);
+  }
+
+  @Test
+  public void oneIncorrect() {
+    List<Token> tokens = tokenizer.tokenize("\tbad  ");
+    assertTokensEqual(of(error("bad")), tokens);
+  }
+
+  @Test
+  public void severalIncorrect() {
+    List<Token> tokens = tokenizer.tokenize(" bad \tinput");
+    assertTokensEqual(of(error("bad"), error("input")), tokens);
+  }
+
+  @Test
+  public void correctAndIncorrect() {
+    List<Token> tokens = tokenizer.tokenize("value bad + 7 ^ 5");
+    assertTokensEqual(of(value(), error("bad"), PLUS, integer(7), error("^"), integer(5)), tokens);
+  }
+
+  @Test
+  public void recoverOnlyAfterSpace() {
+    List<Token> tokens = tokenizer.tokenize("bad+ bad +");
+    assertTokensEqual(of(error("bad+"), error("bad"), PLUS), tokens);
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
@@ -1,0 +1,85 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.ErrorToken;
+import jetbrains.jetpad.hybrid.parser.IntValueToken;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.mapper.ValueExprTextGen;
+import jetbrains.jetpad.hybrid.testapp.mapper.ValueExprCloner;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+class TokensUtil {
+  private TokensUtil() {
+  }
+
+  static Token integer(int val) {
+    return new IntValueToken(val);
+  }
+
+  static Token singleQtd(String body) {
+    return new ValueToken(new StringExpr("'", body), new ValueExprCloner(), new ValueExprTextGen());
+  }
+
+  static Token doubleQtd(String body) {
+    return new ValueToken(new StringExpr("\"", body), new ValueExprCloner(), new ValueExprTextGen());
+  }
+
+  static Token complex() {
+    return new ValueToken(new ComplexValueExpr(), new ValueExprCloner());
+  }
+
+  static Token pos() {
+    return new ValueToken(new PosValueExpr(), new ValueExprCloner());
+  }
+
+  static Token value() {
+    return new ValueToken(new ValueExpr(), new ValueExprCloner());
+  }
+
+  static Token async() {
+    return new ValueToken(new AsyncValueExpr(), new ValueExprCloner());
+  }
+  static Token error(String text) {
+    return new ErrorToken(text);
+  }
+
+  static void assertTokensEqual(List<Token> expected, List<Token> actual) {
+    assertEquals(expected.size(), actual.size());
+    for (int i = 0; i < expected.size(); i++) {
+      Token expectedToken = expected.get(i);
+      Token actualToken = actual.get(i);
+      if (expectedToken instanceof ValueToken) {
+        assertTrue(actualToken instanceof ValueToken);
+        assertValueTokensEqual((ValueToken) expectedToken, (ValueToken) actualToken);
+      } else if (expectedToken instanceof ErrorToken) {
+        assertTrue(actualToken instanceof ErrorToken);
+        assertEquals(expectedToken.toString(), actualToken.toString());
+      } else {
+        assertEquals(expectedToken, actualToken);
+      }
+    }
+  }
+
+  private static void assertValueTokensEqual(ValueToken expected, ValueToken actual) {
+    Object expectedValue = expected.value();
+    Object actualValue = actual.value();
+    if (expectedValue instanceof ValueExpr) {
+      assertTrue(actualValue instanceof ValueExpr);
+      assertEquals(((ValueExpr) expectedValue).val.get(), ((ValueExpr) actualValue).val.get());
+    } else if (expectedValue instanceof ComplexValueExpr) {
+      assertTrue(actualValue instanceof ComplexValueExpr);
+    } else if (expectedValue instanceof PosValueExpr) {
+      assertTrue(actualValue instanceof PosValueExpr);
+    } else if (expectedValue instanceof StringExpr) {
+      assertTrue(actualValue instanceof StringExpr);
+      assertEquals(actualValue.toString(), expectedValue.toString());
+    } else {
+      assertEquals(expectedValue, actualValue);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
@@ -35,6 +35,9 @@ class ExprMapperFactory implements MapperFactory<Object,Cell> {
     if (source instanceof ComplexValueExpr) {
       return new ComplexValueExprMapper((ComplexValueExpr) source);
     }
+    if (source instanceof StringExpr) {
+      return new StringExprMapper((StringExpr) source);
+    }
     throw new IllegalArgumentException("Unknown source: " + source);
   }
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/StringExprMapper.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/StringExprMapper.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.cell.HorizontalCell;
+import jetbrains.jetpad.cell.TextCell;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.cell.text.TextEditing;
+import jetbrains.jetpad.hybrid.testapp.model.StringExpr;
+import jetbrains.jetpad.mapper.Mapper;
+import jetbrains.jetpad.mapper.Synchronizers;
+import jetbrains.jetpad.projectional.cell.ProjectionalSynchronizers;
+
+import static jetbrains.jetpad.cell.util.CellFactory.label;
+import static jetbrains.jetpad.cell.util.CellFactory.to;
+
+class StringExprMapper extends Mapper<StringExpr, StringExprMapper.StringExprCell> {
+  StringExprMapper(StringExpr source) {
+    super(source, new StringExprCell(source.quote.get()));
+  }
+
+  @Override
+  protected void registerSynchronizers(SynchronizersConfiguration conf) {
+    super.registerSynchronizers(conf);
+    conf.add(Synchronizers.forPropsTwoWay(getSource().body, getTarget().body.text()));
+  }
+
+  static class StringExprCell extends HorizontalCell {
+    private final TextCell body = new TextCell();
+
+    private StringExprCell(String quote) {
+      to(
+          this,
+          label(quote, true, false),
+          body,
+          label(quote, false, true)
+      );
+      set(ProjectionalSynchronizers.ON_CREATE, CellActions.toFirstFocusable(body));
+      body.addTrait(TextEditing.textEditing());
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprCloner.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprCloner.java
@@ -1,0 +1,33 @@
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+public class ValueExprCloner implements ValueToken.ValueCloner<Expr> {
+  @Override
+  public Expr clone(Expr val) {
+    if (val instanceof ValueExpr) {
+      ValueExpr result = new ValueExpr();
+      result.val.set(((ValueExpr) val).val.get());
+      return result;
+    }
+
+    if (val instanceof ComplexValueExpr) {
+      return new ComplexValueExpr();
+    }
+
+    if (val instanceof PosValueExpr) {
+      return new PosValueExpr();
+    }
+
+    if (val instanceof AsyncValueExpr) {
+      return new AsyncValueExpr();
+    }
+
+    if (val instanceof StringExpr) {
+      return new StringExpr((StringExpr) val);
+    }
+
+    throw new IllegalArgumentException(val.toString());
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprTextGen.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ValueExprTextGen.java
@@ -1,0 +1,15 @@
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.model.*;
+
+public class ValueExprTextGen implements ValueToken.ValueTextGen<Expr> {
+  @Override
+  public String toText(Expr val) {
+    if (val instanceof StringExpr) {
+      return val.toString();
+    }
+
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/StringExpr.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/StringExpr.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.model;
+
+import jetbrains.jetpad.model.property.Property;
+import jetbrains.jetpad.model.property.ReadOnlyProperty;
+import jetbrains.jetpad.model.property.ValueProperty;
+
+public class StringExpr extends Expr {
+  public final ReadOnlyProperty<String> quote;
+  public final Property<String> body = new ValueProperty<>("");
+
+  public StringExpr(String quote) {
+    this.quote = new ReadOnlyProperty<>(new ValueProperty<>(quote));
+  }
+
+  public StringExpr(String quote, String body) {
+    this(quote);
+    this.body.set(body);
+  }
+
+  public StringExpr(StringExpr toCopy) {
+    this(toCopy.quote.get());
+    this.body.set(toCopy.body.get());
+  }
+
+  @Override
+  public String toString() {
+    return quote.get() + body.get() + quote.get();
+  }
+}

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -851,7 +851,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void cut() {
+  public void cutOneChild() {
     container.children.add(new EmptyChild());
     selectChild(0);
 

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizerTest.java
@@ -204,7 +204,7 @@ public class ProjectionalPropertySynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void cut() {
+  public void cutItem() {
     AutoDeleteChild child = new AutoDeleteChild();
     container.child.set(child);
     focusChild(child);


### PR DESCRIPTION
Changes against previous request https://github.com/JetBrains/jetpad-projectional/pull/134

* Harmonized with recent changes to Hybrid Sync
* In `CellTrait` renamed `onAdded()` to `onAdd()`
* Introduced `CellTrait.onRemove()` which is called very last in on-remove routine, after all other listeners of trait.
* Unexposed `CellContainer.lastSeenText`.
* Instead, used `copy()` and `cut()` methods of `CellContainer`, just like AWT app (`ViewContainerComponent`) does.
* In some projectional tests `cut()` and `copy()` tests renamed in order to avoid overriding methods manipulating the clipboard.
