### PR TITLE
ByBoundsCompletionItem can complete incomplete input

### DIFF
--- a/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
@@ -33,19 +33,31 @@ public abstract class ByBoundsCompletionItem extends BaseCompletionItem {
 
   @Override
   public boolean isStrictMatchPrefix(String text) {
-    return myPrefix.startsWith(text) || isPrefixedButNotSuffixed(text);
+    return text.length() < myPrefix.length() && myPrefix.startsWith(text);
   }
 
   @Override
   public boolean isMatch(String text) {
-    return isPrefixedAndSuffixed(text);
+    return hasPrefixAndDoesNotExceedSuffix(text);
   }
 
-  private boolean isPrefixedButNotSuffixed(String text) {
-    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == -1;
+  private boolean hasPrefixAndDoesNotExceedSuffix(String text) {
+    if (text.startsWith(myPrefix)) {
+      int suffixPos = text.indexOf(mySuffix, myPrefix.length());
+      return (suffixPos == -1) || (suffixPos == text.length() - mySuffix.length());
+    }
+    return false;
   }
 
-  private boolean isPrefixedAndSuffixed(String text) {
-    return text.startsWith(myPrefix) && text.indexOf(mySuffix, myPrefix.length()) == (text.length() - mySuffix.length());
+  protected String getBody(String text) {
+    if (text.startsWith(myPrefix)) {
+      if ((text.length() - myPrefix.length() >= mySuffix.length())
+          && text.endsWith(mySuffix)) {
+        return text.substring(myPrefix.length(), text.length() - mySuffix.length());
+      } else {
+        return text.substring(myPrefix.length());
+      }
+    }
+    return text;
   }
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokenizerTest.java
@@ -86,6 +86,12 @@ public class TokenizerTest {
   }
 
   @Test
+  public void incompleteStringLiteral() {
+    List<Token> tokens = tokenizer.tokenize("\"text 1");
+    assertTokensEqual(of(doubleQtd("text 1")), tokens);
+  }
+
+  @Test
   public void nestedQuotesOfDifferentKind() {
     List<Token> tokens = tokenizer.tokenize("\"'\"'\"'");
     assertTokensEqual(of(doubleQtd("'"), singleQtd("\"")), tokens);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -30,16 +30,6 @@ import java.util.Arrays;
 import java.util.List;
 
 public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
-  private static String dequote(String text, String quote) {
-    if (text.startsWith(quote)) {
-      if (text.length() >= quote.length() * 2 && text.endsWith(quote)) {
-        return text.substring(quote.length(), text.length() - quote.length());
-      }
-      return text.substring(quote.length());
-    }
-    return text;
-  }
-
   private final Token tokenPlus;
   private final Token tokenMul;
 
@@ -340,28 +330,16 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
           }
         });
         for (final String quote : new String[] { "\"", "'" }) {
-          result.add(new SimpleCompletionItem(quote) {
+          result.add(new ByBoundsCompletionItem(quote, quote) {
             @Override
             public Runnable complete(String text) {
               StringExpr stringExpr = new StringExpr(quote);
-              stringExpr.body.set(dequote(text, quote));
+              stringExpr.body.set(getBody(text));
               return tokenHandler.apply(new ValueToken(stringExpr, new ValueExprCloner(), new ValueExprTextGen()));
             }
             @Override
             public int getSortPriority() {
               return -1;
-            }
-          });
-          result.add(new ByBoundsCompletionItem(quote, quote) {
-            @Override
-            public Runnable complete(String text) {
-              StringExpr stringExpr = new StringExpr(quote);
-              stringExpr.body.set(dequote(text, quote));
-              return tokenHandler.apply(new ValueToken(stringExpr, new ValueExprCloner(), new ValueExprTextGen()));
-            }
-            @Override
-            public int getSortPriority() {
-              return -2;
             }
           });
         }


### PR DESCRIPTION
To match, input must start with the prefix and optionally may end with the suffix but must not exceed it. E.g., for strings, `"` will complete to empty string, `"a` and `"a"` will complete to `"a"`, but `"a"b` or `"a""` will not complete.

* This eliminates the need in having two completions (Simple, ByBounds) in Hybrid Specs for strings. ByBounds can do all the work.
* In non-eager-completion cells completion is still possible because there is only one matching item.
* When you paste a string without a closing quote, latter is autocompleted.