### PR TITLE
checking canCreateItem() (newItem IllegalStateException fix)

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
@@ -95,7 +95,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
           return getCurrentChildCompletion();
         }
 
-        if (spec == ITEM_HANDLER) {
+        if (spec == ITEM_HANDLER && canCreateNewItem()) {
           return new ItemHandler() {
             @Override
             public Runnable addEmptyAfter() {

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -901,6 +901,19 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertTrue(Cells.isEmpty(getChild(0)));
   }
 
+  @Test
+  public void addEmptyAfter() {
+    EmptyCompositeChild cc = new EmptyCompositeChild();
+    container.children.add(cc);
+    selectFirst(0);
+
+    enter();
+    enter();
+
+    assertEquals(0, cc.children.size());
+    assertEquals(2, container.children.size());
+  }
+
   private Child get(int index) {
     return container.children.get(index);
   }

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -914,6 +914,22 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertEquals(2, container.children.size());
   }
 
+  @Test
+  public void canCreateItemCheck() {
+    RecordCompositeChild recordCompositeChild = new RecordCompositeChild();
+    container.children.add(recordCompositeChild);
+    CompositeRecord compositeRecord = new CompositeRecord();
+    recordCompositeChild.records.add(compositeRecord);
+    selectFirst(0);
+
+    enter();
+    enter();
+
+    assertEquals(0, compositeRecord.records.size());
+    assertEquals(1, recordCompositeChild.records.size());
+    assertEquals(2, container.children.size());
+  }
+
   private Child get(int index) {
     return container.children.get(index);
   }
@@ -1008,6 +1024,10 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
           return new EmptyCompositeChildMapper((EmptyCompositeChild) source);
         }
 
+        if (source instanceof RecordCompositeChild) {
+          return new RecordCompositeChildMapper((RecordCompositeChild) source);
+        }
+
         if (source instanceof DeleteOnEmptyChild) {
           return new DeleteOnEmptyChildMapper((DeleteOnEmptyChild) source);
         }
@@ -1089,6 +1109,38 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     return result;
   }
 
+  private MapperFactory<Record, Cell> createRecordMapperFactory() {
+    return new MapperFactory<Record, Cell>() {
+      @Override
+      public Mapper<? extends Record, ? extends Cell> createMapper(Record source) {
+        if (source instanceof EmptyRecord) {
+          return new EmptyRecordMapper((EmptyRecord) source);
+        }
+        if (source instanceof CompositeRecord) {
+          return new CompositeRecordMapper((CompositeRecord) source);
+        }
+        return null;
+      }
+    };
+  }
+
+  private ProjectionalRoleSynchronizer<Object, Record> createRecordSynchronizer(
+      Mapper<?, ? extends Cell> contextMapper, Cell target, ObservableList<Record> list, boolean hasItemFactory) {
+    ProjectionalRoleSynchronizer<Object, Record> result =
+        ProjectionalSynchronizers.forRole(contextMapper, list, target, createRecordMapperFactory());
+
+    if (hasItemFactory) {
+      result.setItemFactory(new Supplier<Record>() {
+        @Override
+        public Record get() {
+          return new EmptyRecord();
+        }
+      });
+    }
+
+    return result;
+  }
+
   private void enableItemHandler() {
     rootMapper.getTarget().set(ProjectionalObservableListSynchronizer.ITEM_HANDLER, new ProjectionalObservableListSynchronizer.ItemHandler() {
       @Override
@@ -1102,6 +1154,16 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   private class Container {
     final Property<Boolean> parensVisible = new ValueProperty<>(false);
     final ObservableList<Child> children = new ObservableArrayList<>();
+  }
+
+  private abstract class Record {
+  }
+
+  private class EmptyRecord extends Record {
+  }
+
+  private class CompositeRecord extends Record {
+    final ObservableList<Record> records = new ObservableArrayList<>();
   }
 
   private abstract class Child {
@@ -1122,6 +1184,10 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
 
   private class EmptyCompositeChild extends Child {
     final ObservableList<Child> children = new ObservableArrayList<>();
+  }
+
+  private class RecordCompositeChild extends Child {
+    final ObservableList<Record> records = new ObservableArrayList<>();
   }
 
   private class NonSelectableChild extends Child {
@@ -1341,6 +1407,38 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
       getTarget().children().add(l);
 
       l.focusable().set(true);
+    }
+  }
+
+  private class RecordCompositeChildMapper extends Mapper<RecordCompositeChild, VerticalCell> {
+    private RecordCompositeChildMapper(RecordCompositeChild source) {
+      super(source, new VerticalCell());
+    }
+
+    @Override
+    protected void registerSynchronizers(SynchronizersConfiguration conf) {
+      super.registerSynchronizers(conf);
+      conf.add(createRecordSynchronizer(this, getTarget(), getSource().records, false));
+    }
+  }
+
+  private class EmptyRecordMapper extends Mapper<EmptyRecord, TextCell> {
+    EmptyRecordMapper(EmptyRecord source) {
+      super(source, new TextCell());
+      getTarget().text().set("");
+      getTarget().addTrait(TextEditing.validTextEditing(Validators.equalsTo("")));
+    }
+  }
+
+  private class CompositeRecordMapper extends Mapper<CompositeRecord, VerticalCell> {
+    CompositeRecordMapper(CompositeRecord source) {
+      super(source, new VerticalCell());
+    }
+
+    @Override
+    protected void registerSynchronizers(SynchronizersConfiguration conf) {
+      super.registerSynchronizers(conf);
+      conf.add(createRecordSynchronizer(this, getTarget(), getSource().records, true));
     }
   }
 }


### PR DESCRIPTION
addEmptyAfter test - I discovered that the certain part of code (jetbrains.jetpad.projectional.cell.ProjectionalObservableListSynchronizer.ItemHandler#addEmptyAfter) was not covered by tests. So I added this test. It is the only test that will fail if replace that method body with Runnables.EMPTY.

checking canCreateItem() - the hardest part was to write the test (fail before, pass after). 