### PR TITLE
ability to specify a parsingContext implementation

### DIFF
--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
@@ -30,7 +30,7 @@ import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinterContext;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ExprHybridEditorSpec implements HybridEditorSpec<Expression> {
+public class ExprHybridEditorSpec extends BaseHybridEditorSpec<Expression> {
   @Override
   public Parser<Expression> getParser() {
     return ExpressionParser.PARSER;
@@ -182,7 +182,7 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expression> {
   public CompletionSupplier getAdditionalCompletion(final CompletionContext ctx, final Completer completer) {
     List<Token> input = new ArrayList<>(ctx.getPrefix());
     input.add(new IdentifierToken("dummy"));
-    Expression result = getParser().parse(new ParsingContext(input));
+    Expression result = getParser().parse(getParsingContextFactory().getParsingContext(input));
 
     final Type type;
     if (ctx.getTargetIndex() < ctx.getViews().size() && ctx.getObjects().get(ctx.getTargetIndex()) instanceof Operation) {

--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
@@ -32,7 +32,7 @@ import jetbrains.jetpad.projectional.demo.indentDemo.model.*;
 import java.util.ArrayList;
 import java.util.List;
 
-public class LambdaHybridEditorSpec implements HybridEditorSpec<Expr> {
+public class LambdaHybridEditorSpec extends BaseHybridEditorSpec<Expr> {
   @Override
   public Parser<Expr> getParser() {
     return LambdaParser.EXPR;

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridEditorSpec.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridEditorSpec.java
@@ -13,21 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jetbrains.jetpad.hybrid.parser;
+package jetbrains.jetpad.hybrid;
 
-import java.util.List;
+import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
+import jetbrains.jetpad.hybrid.parser.SimpleParsingContextFactory;
 
-public interface ParsingContext {
+public abstract class BaseHybridEditorSpec<SourceT> implements HybridEditorSpec<SourceT> {
 
-  List<Token> getTokens();
-
-  Token current();
-
-  void advance();
-
-  State saveState();
-
-  interface State {
-    void restore();
+  protected BaseHybridEditorSpec() {
   }
+
+  @Override
+  public ParsingContextFactory getParsingContextFactory() {
+    return new SimpleParsingContextFactory();
+  }
+
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridEditorSpec.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridEditorSpec.java
@@ -1,6 +1,7 @@
 package jetbrains.jetpad.hybrid;
 
 import jetbrains.jetpad.completion.CompletionSupplier;
+import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinter;
 
 public interface SimpleHybridEditorSpec<SourceT> extends TokenCompletion {
@@ -8,4 +9,6 @@ public interface SimpleHybridEditorSpec<SourceT> extends TokenCompletion {
   PairSpec getPairSpec();
 
   CompletionSupplier getAdditionalCompletion(CompletionContext ctx, Completer completer);
+
+  ParsingContextFactory getParsingContextFactory();
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
@@ -22,6 +22,7 @@ import jetbrains.jetpad.cell.util.CellState;
 import jetbrains.jetpad.cell.util.CellStateHandler;
 import jetbrains.jetpad.completion.CompletionSupplier;
 import jetbrains.jetpad.hybrid.parser.Parser;
+import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinter;
 import jetbrains.jetpad.mapper.Mapper;
@@ -56,6 +57,11 @@ public class SimpleHybridSynchronizer<SourceT> extends BaseHybridSynchronizer<So
       @Override
       public CompletionSupplier getAdditionalCompletion(CompletionContext ctx, Completer completer) {
         return spec.getAdditionalCompletion(ctx, completer);
+      }
+
+      @Override
+      public ParsingContextFactory getParsingContextFactory() {
+        return spec.getParsingContextFactory();
       }
     };
   }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenListEditor.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenListEditor.java
@@ -139,7 +139,9 @@ class TokenListEditor<SourceT> {
         toParse.add(t.copy());
       }
 
-      SourceT result = mySpec.get().getParser().parse(new ParsingContext(toParse));
+      HybridEditorSpec<SourceT> hybridEditorSpec = mySpec.get();
+      ParsingContext parsingContext = hybridEditorSpec.getParsingContextFactory().getParsingContext(toParse);
+      SourceT result = hybridEditorSpec.getParser().parse(parsingContext);
       if (result != null) {
         value.set(result);
         myValid.set(true);

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ParsingContextFactory.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/ParsingContextFactory.java
@@ -17,17 +17,8 @@ package jetbrains.jetpad.hybrid.parser;
 
 import java.util.List;
 
-public interface ParsingContext {
+public interface ParsingContextFactory {
 
-  List<Token> getTokens();
+  ParsingContext getParsingContext(List<Token> tokenList);
 
-  Token current();
-
-  void advance();
-
-  State saveState();
-
-  interface State {
-    void restore();
-  }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContext.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContext.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.parser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+class SimpleParsingContext implements ParsingContext {
+  private List<Token> myTokens;
+  private int myPosition;
+
+  SimpleParsingContext(List<Token> tokens) {
+    myTokens = new ArrayList<>(tokens);
+  }
+
+  public List<Token> getTokens() {
+    return Collections.unmodifiableList(myTokens);
+  }
+
+  public Token current() {
+    if (myPosition > myTokens.size() - 1) return null;
+    return myTokens.get(myPosition);
+  }
+
+  public void advance() {
+    myPosition++;
+  }
+
+  public State saveState() {
+    return new SimpleState();
+  }
+
+  public class SimpleState implements State {
+    private int myPosition;
+
+    private SimpleState() {
+      myPosition = SimpleParsingContext.this.myPosition;
+    }
+
+    public void restore() {
+      SimpleParsingContext.this.myPosition = myPosition;
+    }
+  }
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContextFactory.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContextFactory.java
@@ -17,17 +17,14 @@ package jetbrains.jetpad.hybrid.parser;
 
 import java.util.List;
 
-public interface ParsingContext {
+public final class SimpleParsingContextFactory implements ParsingContextFactory {
 
-  List<Token> getTokens();
-
-  Token current();
-
-  void advance();
-
-  State saveState();
-
-  interface State {
-    void restore();
+  public SimpleParsingContextFactory() {
   }
+
+  @Override
+  public ParsingContext getParsingContext(List<Token> tokenList) {
+    return new SimpleParsingContext(tokenList);
+  }
+
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/SimpleHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/SimpleHybridProperty.java
@@ -18,7 +18,7 @@ package jetbrains.jetpad.hybrid.util;
 import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.parser.Parser;
-import jetbrains.jetpad.hybrid.parser.ParsingContext;
+import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.model.collections.CollectionItemEvent;
 import jetbrains.jetpad.model.collections.list.ObservableList;
@@ -29,13 +29,15 @@ public class SimpleHybridProperty<ModelT> extends BaseDerivedProperty<ModelT> im
 
   private final Parser<ModelT> myParser;
   private final ObservableList<Token> myTokens;
+  private final ParsingContextFactory myParsingContextFactory;
 
   private Registration myRegistration;
 
-  public SimpleHybridProperty(Parser<ModelT> parser, ObservableList<Token> tokens) {
-    super(parser.parse(new ParsingContext(tokens)));
+  public SimpleHybridProperty(Parser<ModelT> parser, ObservableList<Token> tokens, ParsingContextFactory parsingContextFactory) {
+    super(parser.parse(parsingContextFactory.getParsingContext(tokens)));
     myParser = parser;
     myTokens = tokens;
+    myParsingContextFactory = parsingContextFactory;
   }
 
   @Override
@@ -55,7 +57,7 @@ public class SimpleHybridProperty<ModelT> extends BaseDerivedProperty<ModelT> im
 
   @Override
   protected ModelT doGet() {
-    return myParser.parse(new ParsingContext(myTokens));
+    return myParser.parse(myParsingContextFactory.getParsingContext(myTokens));
   }
 
   @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
+public class ExprHybridEditorSpec extends BaseHybridEditorSpec<Expr> {
   private final Token tokenPlus;
   private final Token tokenMul;
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/util/SimpleHybridPropertyTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/util/SimpleHybridPropertyTest.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.hybrid.util;
 
+import jetbrains.jetpad.hybrid.HybridEditorSpec;
 import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.parser.ErrorToken;
 import jetbrains.jetpad.hybrid.parser.IdentifierToken;
@@ -39,7 +40,8 @@ public class SimpleHybridPropertyTest extends BaseTestCase {
   @Before
   public void init() {
     myTokens = new ObservableArrayList<>();
-    myProp = new SimpleHybridProperty<>(new ExprHybridEditorSpec().getParser(), myTokens);
+    HybridEditorSpec<Expr> hybridEditorSpec = new ExprHybridEditorSpec();
+    myProp = new SimpleHybridProperty<>(hybridEditorSpec.getParser(), myTokens, hybridEditorSpec.getParsingContextFactory());
   }
 
   @Test


### PR DESCRIPTION
There are pull requests in 3 different repositories (jetpad-projectional, jetpad-ot, datapad). They all have name: "ability to specify a parsingContext implementation". The main one is jetpad-projectional. The other two are updates of usages so that the compilation doesn't fail.

We need this to provide a different implementation of ParsingContext. For  example, to filter out comment tokens.