### PR TITLE
SimpleParsingContext is public

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContext.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/SimpleParsingContext.java
@@ -19,11 +19,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-class SimpleParsingContext implements ParsingContext {
+public class SimpleParsingContext implements ParsingContext {
   private List<Token> myTokens;
   private int myPosition;
 
-  SimpleParsingContext(List<Token> tokens) {
+  public SimpleParsingContext(List<Token> tokens) {
     myTokens = new ArrayList<>(tokens);
   }
 


### PR DESCRIPTION
So that we could reuse this default implementation. 
I could use this implementation instead of PyParsingContext which is the exact copy of SimpleParsingContext. I did the comment filtering in PyParsingContextFactory.