### PR TITLE
access to token list in token completion

### DIFF
--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
@@ -161,7 +161,7 @@ public class ExprHybridEditorSpec extends BaseHybridEditorSpec<Expression> {
   }
 
   @Override
-  public CompletionSupplier getTokenCompletion(final Function<Token, Runnable> tokenHandler) {
+  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, final Function<Token, Runnable> tokenHandler) {
     return new CompletionSupplier() {
       @Override
       public List<CompletionItem> get(CompletionParameters cp) {

--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
@@ -81,7 +81,7 @@ public class LambdaHybridEditorSpec extends BaseHybridEditorSpec<Expr> {
   }
 
   @Override
-  public CompletionSupplier getTokenCompletion(final Function<Token, Runnable> tokenHandler) {
+  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, final Function<Token, Runnable> tokenHandler) {
     return new CompletionSupplier() {
       @Override
       public List<CompletionItem> get(CompletionParameters cp) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/CompletionContext.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/CompletionContext.java
@@ -22,14 +22,18 @@ import jetbrains.jetpad.cell.Cell;
 import java.util.List;
 
 public interface CompletionContext {
-  public static final CompletionContext EMPTY = new EmptyCompletionContext();
+  CompletionContext EMPTY = new EmptyCompletionContext();
+  CompletionContext UNSUPPORTED = new UnsupportedCompletionContext();
 
   int getTargetIndex();
 
   List<Token> getPrefix();
 
   List<Cell> getViews();
+
   List<Token> getTokens();
+  Token removeToken(int index);
+
   List<Object> getObjects();
 
   Mapper<?, ?> getContextMapper();

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
@@ -53,8 +53,8 @@ public class SimpleHybridSynchronizer<SourceT> extends BaseHybridSynchronizer<So
       }
 
       @Override
-      public CompletionSupplier getTokenCompletion(Function<Token, Runnable> tokenHandler) {
-        return spec.getTokenCompletion(tokenHandler);
+      public CompletionSupplier getTokenCompletion(CompletionContext completionContext, Function<Token, Runnable> tokenHandler) {
+        return spec.getTokenCompletion(completionContext, tokenHandler);
       }
 
       @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompleter.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompleter.java
@@ -64,7 +64,7 @@ class TokenCompleter {
   }
 
   CompletionItems completion(Function<Token, Runnable> handler) {
-    return new CompletionItems(getEditorSpec().getTokenCompletion(handler).get(CompletionParameters.EMPTY));
+    return new CompletionItems(getEditorSpec().getTokenCompletion(CompletionContext.UNSUPPORTED, handler).get(CompletionParameters.EMPTY));
   }
 
   CompletionSupplier placeholderCompletion(final Cell placeholder) {
@@ -203,7 +203,7 @@ class TokenCompleter {
       public List<CompletionItem> get(CompletionParameters cp) {
         List<CompletionItem> result = new ArrayList<>();
         if (!(cp.isMenu() && mySync.isHideTokensInMenu())) {
-          result.addAll(FluentIterable.from(getEditorSpec().getTokenCompletion(new Function<Token, Runnable>() {
+          result.addAll(FluentIterable.from(getEditorSpec().getTokenCompletion(ctx, new Function<Token, Runnable>() {
             @Override
             public Runnable apply(Token input) {
               return completer.complete(input);
@@ -278,6 +278,11 @@ class TokenCompleter {
     }
 
     @Override
+    public Token removeToken(int index) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public List<Object> getObjects() {
       return Collections.emptyList();
     }
@@ -318,6 +323,11 @@ class TokenCompleter {
     @Override
     public List<Token> getTokens() {
       return Collections.unmodifiableList(getTokeListEditor().tokens);
+    }
+
+    @Override
+    public Token removeToken(int index) {
+      return getTokeListEditor().tokens.remove(index);
     }
 
     @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletion.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.jetpad.hybrid;
 
 import com.google.common.base.Function;
@@ -5,5 +20,5 @@ import jetbrains.jetpad.completion.CompletionSupplier;
 import jetbrains.jetpad.hybrid.parser.Token;
 
 public interface TokenCompletion {
-  public CompletionSupplier getTokenCompletion(final Function<Token, Runnable> tokenHandler);
+  CompletionSupplier getTokenCompletion(CompletionContext completionContext, Function<Token, Runnable> tokenHandler);
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
@@ -93,7 +93,7 @@ class Tokenizer {
   private class TextMatcher {
     private final Value<Token> tokenHolder = new Value<>();
     private final CompletionItems completionItems = new CompletionItems(
-        mySpec.getTokenCompletion(new Function<Token, Runnable>() {
+        mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, new Function<Token, Runnable>() {
           @Nullable
           @Override
           public Runnable apply(@Nullable final Token token) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/UnsupportedCompletionContext.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/UnsupportedCompletionContext.java
@@ -19,28 +19,31 @@ import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.mapper.Mapper;
 
-import java.util.ArrayList;
 import java.util.List;
 
-class EmptyCompletionContext implements CompletionContext {
+final class UnsupportedCompletionContext implements CompletionContext {
+
+  UnsupportedCompletionContext() {
+  }
+
   @Override
   public int getTargetIndex() {
-    return 0;
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public List<Token> getPrefix() {
-    return new ArrayList<>();
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public List<Cell> getViews() {
-    return new ArrayList<>();
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public List<Token> getTokens() {
-    return new ArrayList<>();
+    throw new UnsupportedOperationException();
   }
 
   @Override
@@ -50,16 +53,17 @@ class EmptyCompletionContext implements CompletionContext {
 
   @Override
   public List<Object> getObjects() {
-    return new ArrayList<>();
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public Mapper<?, ?> getContextMapper() {
-    return null;
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public Object getTarget() {
-    return null;
+    throw new UnsupportedOperationException();
   }
+
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/HybridWrapperRole.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/HybridWrapperRole.java
@@ -73,7 +73,7 @@ public class HybridWrapperRole<ContainerT, WrapperT, TargetT> implements RoleCom
         };
 
         if (!(cp.isMenu() && myHideTokensInMenu)) {
-          for (CompletionItem ci : mySpec.getTokenCompletion(new Function<Token, Runnable>() {
+          for (CompletionItem ci : mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, new Function<Token, Runnable>() {
             @Override
             public Runnable apply(Token input) {
               return completer.complete(input);
@@ -108,6 +108,11 @@ public class HybridWrapperRole<ContainerT, WrapperT, TargetT> implements RoleCom
             @Override
             public List<Token> getTokens() {
               return Collections.emptyList();
+            }
+
+            @Override
+            public Token removeToken(int index) {
+              throw new UnsupportedOperationException();
             }
 
             @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -33,6 +33,7 @@ import jetbrains.jetpad.completion.*;
 import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.hybrid.parser.*;
 import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.hybrid.testapp.mapper.ValueExprNodeCloner;
 import jetbrains.jetpad.hybrid.testapp.model.*;
 import jetbrains.jetpad.hybrid.util.HybridWrapperRole;
 import jetbrains.jetpad.mapper.Mapper;
@@ -415,9 +416,7 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     select(1, false);
 
     complete();
-    down();
-    down();
-    down();
+    type("*");
     enter();
 
     assertTokens(Tokens.ID, Tokens.DOT, Tokens.MUL);
@@ -1019,12 +1018,22 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     assertTrue(FluentIterable.from(completionItems).isEmpty());
   }
 
+  @Test
+  public void commentInTheMiddle() {
+    setTokens(integer(1), Tokens.PLUS, integer(2), Tokens.PLUS, integer(3));
+    select(2, false);
+
+    type("#");
+
+    assertTokens(integer(1), Tokens.PLUS, integer(2), new ValueToken(new Comment("+3"), new ValueExprNodeCloner()));
+  }
+
   protected ValueToken createComplexToken() {
     return new ValueToken(new ComplexValueExpr(), new ComplexValueCloner());
   }
 
   protected void assertTokens(Token... tokens) {
-    assertEquals(Arrays.asList(tokens), sync.tokens());
+    TokensUtil.assertTokensEqual(Arrays.asList(tokens), sync.tokens());
   }
 
   protected void setTokens(Token... tokens) {

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
@@ -78,6 +78,9 @@ class TokensUtil {
     } else if (expectedValue instanceof StringExpr) {
       assertTrue(actualValue instanceof StringExpr);
       assertEquals(actualValue.toString(), expectedValue.toString());
+    } else if (expectedValue instanceof Comment) {
+      assertTrue(actualValue instanceof Comment);
+      assertEquals(((Comment) expectedValue).text.get(), ((Comment) actualValue).text.get());
     } else {
       assertEquals(expectedValue, actualValue);
     }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/CommentMapper.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/CommentMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.testapp.mapper;
+
+import jetbrains.jetpad.cell.HorizontalCell;
+import jetbrains.jetpad.cell.TextCell;
+import jetbrains.jetpad.cell.action.CellActions;
+import jetbrains.jetpad.cell.text.TextEditing;
+import jetbrains.jetpad.hybrid.testapp.model.Comment;
+import jetbrains.jetpad.mapper.Mapper;
+import jetbrains.jetpad.mapper.Synchronizers;
+import jetbrains.jetpad.projectional.cell.ProjectionalSynchronizers;
+
+import static jetbrains.jetpad.cell.util.CellFactory.label;
+import static jetbrains.jetpad.cell.util.CellFactory.to;
+
+final class CommentMapper extends Mapper<Comment, CommentMapper.CommentCell> {
+  CommentMapper(Comment source) {
+    super(source, new CommentCell());
+  }
+
+  @Override
+  protected void registerSynchronizers(SynchronizersConfiguration conf) {
+    super.registerSynchronizers(conf);
+    conf.add(Synchronizers.forPropsTwoWay(getSource().text, getTarget().text.text()));
+  }
+
+  static final class CommentCell extends HorizontalCell {
+    private final TextCell text = new TextCell();
+
+    private CommentCell() {
+      to(
+          this,
+          label("#", true, false),
+          text
+      );
+      set(ProjectionalSynchronizers.ON_CREATE, CellActions.toFirstFocusable(text));
+      text.addTrait(TextEditing.textEditing());
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprMapperFactory.java
@@ -22,7 +22,7 @@ import jetbrains.jetpad.mapper.MapperFactory;
 
 class ExprMapperFactory implements MapperFactory<Object,Cell> {
   @Override
-  public Mapper<? extends Expr, ? extends Cell> createMapper(Object source) {
+  public Mapper<? extends ExprNode, ? extends Cell> createMapper(Object source) {
     if (source instanceof PosValueExpr) {
       return new PosValueExprMapper((PosValueExpr) source);
     }
@@ -37,6 +37,9 @@ class ExprMapperFactory implements MapperFactory<Object,Cell> {
     }
     if (source instanceof StringExpr) {
       return new StringExprMapper((StringExpr) source);
+    }
+    if (source instanceof Comment) {
+      return new CommentMapper((Comment) source);
     }
     throw new IllegalArgumentException("Unknown source: " + source);
   }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/Comment.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/Comment.java
@@ -20,4 +20,17 @@ import jetbrains.jetpad.model.property.ValueProperty;
 
 public class Comment extends ExprNode {
   public Property<String> text = new ValueProperty<>();
+
+  public Comment() {
+  }
+
+  public Comment(String text) {
+    this.text.set(text);
+  }
+
+  @Override
+  public String toString() {
+    return "'#" + text.get() + "'";
+  }
+
 }


### PR DESCRIPTION
We need access to the token list in token completion for comment completion so that we can get the text for the tokens after the comment and then delete those tokens. 
See BaseHybridEditorEditingTest.commentInTheMiddle()

Interface changes:
* new completionContext parameter in tokenCompletion.getTokenCompletion()
* new removeToken(index) method in CompletionContext

Because of the change in tokenCompletion.getTokenCompletion(), the implementing classes has to be updated. As a result we have changed in jetpad-ot (funlang, lambda, modelUtil, workflow) and datapad.
There are three pull requests ("access to token list in token completion").

I'm passing 4 instances of CompletionContext.UNSUPPORTED. It looks like we don't need them in all 4 cases. If we come across such cases, we'll have to think about how to implement completion context there.

We need Katya's approval in projectional first. Then Gleb's merge in all three repositories.
I talked to Kostya about these changes.