### PR TITLE
RuleContext can return matched lexemes

### DIFF
--- a/grammar/src/main/java/jetbrains/jetpad/grammar/RuleContext.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/RuleContext.java
@@ -17,6 +17,9 @@ package jetbrains.jetpad.grammar;
 
 
 import com.google.common.collect.Range;
+import jetbrains.jetpad.grammar.parser.Lexeme;
+
+import java.util.List;
 
 public interface RuleContext {
   ParserParameters getParams();
@@ -26,4 +29,5 @@ public interface RuleContext {
   <ValueT> ValueT get(ParserParameter<ValueT> key);
 
   Range<Integer> getRange();
+  List<Lexeme> getLexemes();
 }

--- a/grammar/src/main/java/jetbrains/jetpad/grammar/parser/LRParser.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/parser/LRParser.java
@@ -84,7 +84,7 @@ public class LRParser {
         Collections.reverse(handlerInput);
 
         LRParserState nextState = stack.peek().state.getNextState(reduce.getRule().getHead());
-        RuleContext ruleContext = new MyRuleContext(Range.closed(startOffset, pos), handlerInput);
+        RuleContext ruleContext = new MyRuleContext(Range.closed(startOffset, pos), handlerInput, input);
         RuleHandler handler = handlerProvider.apply(reduce.getRule());
         Object result = handler != null ? handler.handle(ruleContext) : handlerInput;
 
@@ -114,12 +114,14 @@ public class LRParser {
   }
 
   private class MyRuleContext implements RuleContext {
-    private List<Object> myValues;
-    private Range<Integer> myRange;
+    private final List<Object> myValues;
+    private final Range<Integer> myRange;
+    private final List<Lexeme> myInput;
 
-    private MyRuleContext(Range<Integer> range, List<Object> values) {
+    private MyRuleContext(Range<Integer> range, List<Object> values, List<Lexeme> input) {
       myValues = values;
       myRange = range;
+      myInput = input;
     }
 
     @Override
@@ -145,6 +147,11 @@ public class LRParser {
     @Override
     public Range<Integer> getRange() {
       return myRange;
+    }
+
+    @Override
+    public List<Lexeme> getLexemes() {
+      return Collections.unmodifiableList(myInput.subList(myRange.lowerEndpoint(), myRange.upperEndpoint()));
     }
   }
 }

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
@@ -20,7 +20,7 @@ import jetbrains.jetpad.grammar.slr.SLRTableGenerator;
 import org.junit.Test;
 
 import static jetbrains.jetpad.grammar.GrammarSugar.*;
-import static jetbrains.jetpad.grammar.GrammarTestUtil.asTokens;
+import static jetbrains.jetpad.grammar.GrammarTestUtil.asLexemes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -33,7 +33,7 @@ public class GrammarSugarTest {
 
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, id)));
     assertFalse(parser.parse(id));
   }
 
@@ -46,8 +46,8 @@ public class GrammarSugarTest {
 
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[]", "" + parser.parse(asTokens()));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[]", "" + parser.parse(asLexemes()));
     assertFalse(parser.parse(error));
   }
 
@@ -61,8 +61,8 @@ public class GrammarSugarTest {
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
     assertFalse(parser.parse(error));
-    assertEquals("[]", "" + parser.parse(asTokens(new Terminal[0])));
-    assertEquals("[id, id, id]", "" + parser.parse(asTokens(id, id, id)));
+    assertEquals("[]", "" + parser.parse(asLexemes(new Terminal[0])));
+    assertEquals("[id, id, id]", "" + parser.parse(asLexemes(id, id, id)));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class GrammarSugarTest {
 
     assertFalse(parser.parse(error));
     assertFalse(parser.parse(new Terminal[0]));
-    assertEquals("[id, id, id]", "" + parser.parse(asTokens(id, id, id)));
+    assertEquals("[id, id, id]", "" + parser.parse(asLexemes(id, id, id)));
   }
 
   @Test
@@ -91,9 +91,9 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id, comma));
     assertFalse(parser.parse(id, comma, id, comma));
-    assertEquals("[]", "" + parser.parse(asTokens()));
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+    assertEquals("[]", "" + parser.parse(asLexemes()));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id)));
   }
 
   @Test
@@ -109,8 +109,8 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id, comma));
     assertFalse(parser.parse(id, comma, id, comma));
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id)));
   }
 
   @Test
@@ -126,8 +126,8 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id));
     assertFalse(parser.parse(id, comma, id));
-    assertEquals("[id]", "" + parser.parse(asTokens(id, comma)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id, comma)));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id, comma)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id, comma)));
   }
 
   @Test
@@ -141,9 +141,9 @@ public class GrammarSugarTest {
 
     assertFalse(parser.parse(new Terminal[0]));
     assertFalse(parser.parse(comma));
-    assertEquals("[[id], []]", "" + parser.parse(asTokens(id)));
-    assertEquals("[[id, id], []]", "" + parser.parse(asTokens(id, comma, id)));
-    assertEquals("[[id], [,]]", "" + parser.parse(asTokens(id, comma)));
-    assertEquals("[[id, id], [,]]", "" + parser.parse(asTokens(id, comma, id, comma)));
+    assertEquals("[[id], []]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[[id, id], []]", "" + parser.parse(asLexemes(id, comma, id)));
+    assertEquals("[[id], [,]]", "" + parser.parse(asLexemes(id, comma)));
+    assertEquals("[[id, id], [,]]", "" + parser.parse(asLexemes(id, comma, id, comma)));
   }
 }

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarTestUtil.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarTestUtil.java
@@ -17,12 +17,19 @@ package jetbrains.jetpad.grammar;
 
 import jetbrains.jetpad.grammar.parser.Lexeme;
 
-public class GrammarTestUtil {
-  public static Lexeme[] asTokens(Terminal... ts) {
+import java.util.Arrays;
+import java.util.List;
+
+class GrammarTestUtil {
+  static Lexeme[] asLexemes(Terminal... ts) {
     Lexeme[] result = new Lexeme[ts.length];
     for (int i = 0; i < ts.length; i++) {
       result[i] = new Lexeme(ts[i], "" + ts[i]);
     }
     return result;
+  }
+
+  static List<Lexeme> asLexemesList(Terminal... ts) {
+    return Arrays.asList(asLexemes(ts));
   }
 }


### PR DESCRIPTION
This is needed to satisfy an order of setting something to model part edited with Hybrid Sync. See `SimpleHybridSync` which needs `HybridProperty`. To set into such a model, you need not parsed wrapper but list of tokens instead.