### PR TITLE
RuleContext can return matched lexemes values

### DIFF
--- a/grammar/src/main/java/jetbrains/jetpad/grammar/RuleContext.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/RuleContext.java
@@ -18,6 +18,8 @@ package jetbrains.jetpad.grammar;
 
 import com.google.common.collect.Range;
 
+import java.util.List;
+
 public interface RuleContext {
   ParserParameters getParams();
   Object get(int index);
@@ -26,4 +28,5 @@ public interface RuleContext {
   <ValueT> ValueT get(ParserParameter<ValueT> key);
 
   Range<Integer> getRange();
+  List getLexemeValues();
 }

--- a/grammar/src/main/java/jetbrains/jetpad/grammar/parser/LRParser.java
+++ b/grammar/src/main/java/jetbrains/jetpad/grammar/parser/LRParser.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.grammar.parser;
 
 import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import jetbrains.jetpad.grammar.*;
 
@@ -84,7 +85,7 @@ public class LRParser {
         Collections.reverse(handlerInput);
 
         LRParserState nextState = stack.peek().state.getNextState(reduce.getRule().getHead());
-        RuleContext ruleContext = new MyRuleContext(Range.closed(startOffset, pos), handlerInput);
+        RuleContext ruleContext = new MyRuleContext(Range.closed(startOffset, pos), handlerInput, input);
         RuleHandler handler = handlerProvider.apply(reduce.getRule());
         Object result = handler != null ? handler.handle(ruleContext) : handlerInput;
 
@@ -114,12 +115,14 @@ public class LRParser {
   }
 
   private class MyRuleContext implements RuleContext {
-    private List<Object> myValues;
-    private Range<Integer> myRange;
+    private final List<Object> myValues;
+    private final Range<Integer> myRange;
+    private final List<Lexeme> myInput;
 
-    private MyRuleContext(Range<Integer> range, List<Object> values) {
+    private MyRuleContext(Range<Integer> range, List<Object> values, List<Lexeme> input) {
       myValues = values;
       myRange = range;
+      myInput = input;
     }
 
     @Override
@@ -145,6 +148,18 @@ public class LRParser {
     @Override
     public Range<Integer> getRange() {
       return myRange;
+    }
+
+    @Override
+    public List getLexemeValues() {
+      List<Lexeme> matchedLexemes = myInput.subList(myRange.lowerEndpoint(), myRange.upperEndpoint());
+      return Collections.unmodifiableList(
+          Lists.transform(matchedLexemes, new Function<Lexeme, Object>() {
+            @Override
+            public Object apply(Lexeme lexeme) {
+              return lexeme.getValue();
+            }
+          }));
     }
   }
 }

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/BaseParserGenerationTest.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/BaseParserGenerationTest.java
@@ -21,10 +21,11 @@ import jetbrains.jetpad.grammar.parser.LRParserTable;
 import jetbrains.jetpad.grammar.parser.Lexeme;
 import org.junit.Test;
 
-import static jetbrains.jetpad.grammar.GrammarTestUtil.asTokens;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.of;
+import static jetbrains.jetpad.grammar.GrammarTestUtil.asLexemes;
+import static org.junit.Assert.*;
 
 public abstract class BaseParserGenerationTest {
   protected abstract LRParserTable generateTable(Grammar g);
@@ -106,7 +107,7 @@ public abstract class BaseParserGenerationTest {
     g.plusRule.setAssociativity(Associativity.LEFT).setPriority(0);
 
     LRParser parser = new LRParser(generateTable(g.grammar));
-    Object parse = parser.parse(asTokens(g.id, g.plus, g.id, g.plus, g.id));
+    Object parse = parser.parse(asLexemes(g.id, g.plus, g.id, g.plus, g.id));
 
     assertEquals("((id + id) + id)", parse.toString());
   }
@@ -117,7 +118,7 @@ public abstract class BaseParserGenerationTest {
     g.plusRule.setAssociativity(Associativity.RIGHT).setPriority(0);
 
     LRParser parser = new LRParser(generateTable(g.grammar));
-    Object parse = parser.parse(asTokens(g.id, g.plus, g.id, g.plus, g.id));
+    Object parse = parser.parse(asLexemes(g.id, g.plus, g.id, g.plus, g.id));
 
     assertEquals("(id + (id + id))", parse.toString());
   }
@@ -135,7 +136,7 @@ public abstract class BaseParserGenerationTest {
     LRParserTable table = generateTable(g.grammar);
     LRParser parser = new LRParser(table);
 
-    Object parse = parser.parse(asTokens(g.id, g.plus, g.id, g.mul, g.id));
+    Object parse = parser.parse(asLexemes(g.id, g.plus, g.id, g.mul, g.id));
 
     assertEquals("(id + (id * id))", parse.toString());
   }
@@ -149,11 +150,16 @@ public abstract class BaseParserGenerationTest {
     LRParserTable table = generateTable(g.grammar);
 
     LRParser parser = new LRParser(table);
-    BinExpr parse = (BinExpr) parser.parse(asTokens(g.id, g.plus, g.id));
+    BinExpr parse = (BinExpr) parser.parse(asLexemes(g.id, g.plus, g.id));
 
     assertEquals(Range.closed(0, 3), parse.getRange());
+    assertEquals(of("id", "+", "id"), parse.getLexemesValues());
+
     assertEquals(Range.closed(0, 1), parse.left.getRange());
+    assertEquals(of("id"), parse.left.getLexemesValues());
+
     assertEquals(Range.closed(2, 3), parse.right.getRange());
+    assertEquals(of("id"), parse.right.getLexemesValues());
   }
 
   private class SimplePrecedenceGrammar {
@@ -179,7 +185,7 @@ public abstract class BaseParserGenerationTest {
       idRule.setHandler(new RuleHandler() {
         @Override
         public Object handle(RuleContext ctx) {
-          return new IdExpr(ctx.getRange());
+          return new IdExpr(ctx.getRange(), ctx.getLexemeValues());
         }
       });
 
@@ -192,7 +198,7 @@ public abstract class BaseParserGenerationTest {
         Expr left = (Expr) ctx.get(0);
         Lexeme sign = (Lexeme) ctx.get(1);
         Expr right = (Expr) ctx.get(2);
-        return new BinExpr(left, right, sign.getTerminal(), ctx.getRange());
+        return new BinExpr(left, right, sign.getTerminal(), ctx.getRange(), ctx.getLexemeValues());
       }
     }
   }
@@ -209,19 +215,25 @@ public abstract class BaseParserGenerationTest {
 
   private abstract class Expr {
     private Range<Integer> myRange;
+    private List<Object> myLexemesValues;
 
-    protected Expr(Range<Integer> range) {
+    protected Expr(Range<Integer> range, List<Object> lexemesValues) {
       myRange = range;
+      myLexemesValues = lexemesValues;
     }
 
     Range<Integer> getRange() {
       return myRange;
     }
+
+    List<Object> getLexemesValues() {
+      return myLexemesValues;
+    }
   }
 
   private class IdExpr extends Expr {
-    private IdExpr(Range<Integer> range) {
-      super(range);
+    private IdExpr(Range<Integer> range, List<Object> lexemesValues) {
+      super(range, lexemesValues);
     }
 
     @Override
@@ -235,8 +247,8 @@ public abstract class BaseParserGenerationTest {
     final Expr right;
     final Terminal symbol;
 
-    private BinExpr(Expr left, Expr right, Terminal symbol, Range<Integer> range) {
-      super(range);
+    private BinExpr(Expr left, Expr right, Terminal symbol, Range<Integer> range, List<Object> lexemesValues) {
+      super(range, lexemesValues);
       this.left = left;
       this.right = right;
       this.symbol = symbol;

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarSugarTest.java
@@ -20,7 +20,7 @@ import jetbrains.jetpad.grammar.slr.SLRTableGenerator;
 import org.junit.Test;
 
 import static jetbrains.jetpad.grammar.GrammarSugar.*;
-import static jetbrains.jetpad.grammar.GrammarTestUtil.asTokens;
+import static jetbrains.jetpad.grammar.GrammarTestUtil.asLexemes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -33,7 +33,7 @@ public class GrammarSugarTest {
 
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, id)));
     assertFalse(parser.parse(id));
   }
 
@@ -46,8 +46,8 @@ public class GrammarSugarTest {
 
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[]", "" + parser.parse(asTokens()));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[]", "" + parser.parse(asLexemes()));
     assertFalse(parser.parse(error));
   }
 
@@ -61,8 +61,8 @@ public class GrammarSugarTest {
     LRParser parser = new LRParser(new SLRTableGenerator(g).generateTable());
 
     assertFalse(parser.parse(error));
-    assertEquals("[]", "" + parser.parse(asTokens(new Terminal[0])));
-    assertEquals("[id, id, id]", "" + parser.parse(asTokens(id, id, id)));
+    assertEquals("[]", "" + parser.parse(asLexemes(new Terminal[0])));
+    assertEquals("[id, id, id]", "" + parser.parse(asLexemes(id, id, id)));
   }
 
   @Test
@@ -76,7 +76,7 @@ public class GrammarSugarTest {
 
     assertFalse(parser.parse(error));
     assertFalse(parser.parse(new Terminal[0]));
-    assertEquals("[id, id, id]", "" + parser.parse(asTokens(id, id, id)));
+    assertEquals("[id, id, id]", "" + parser.parse(asLexemes(id, id, id)));
   }
 
   @Test
@@ -91,9 +91,9 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id, comma));
     assertFalse(parser.parse(id, comma, id, comma));
-    assertEquals("[]", "" + parser.parse(asTokens()));
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+    assertEquals("[]", "" + parser.parse(asLexemes()));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id)));
   }
 
   @Test
@@ -109,8 +109,8 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id, comma));
     assertFalse(parser.parse(id, comma, id, comma));
-    assertEquals("[id]", "" + parser.parse(asTokens(id)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id)));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id)));
   }
 
   @Test
@@ -126,8 +126,8 @@ public class GrammarSugarTest {
     assertFalse(parser.parse(comma));
     assertFalse(parser.parse(id));
     assertFalse(parser.parse(id, comma, id));
-    assertEquals("[id]", "" + parser.parse(asTokens(id, comma)));
-    assertEquals("[id, id]", "" + parser.parse(asTokens(id, comma, id, comma)));
+    assertEquals("[id]", "" + parser.parse(asLexemes(id, comma)));
+    assertEquals("[id, id]", "" + parser.parse(asLexemes(id, comma, id, comma)));
   }
 
   @Test
@@ -141,9 +141,9 @@ public class GrammarSugarTest {
 
     assertFalse(parser.parse(new Terminal[0]));
     assertFalse(parser.parse(comma));
-    assertEquals("[[id], []]", "" + parser.parse(asTokens(id)));
-    assertEquals("[[id, id], []]", "" + parser.parse(asTokens(id, comma, id)));
-    assertEquals("[[id], [,]]", "" + parser.parse(asTokens(id, comma)));
-    assertEquals("[[id, id], [,]]", "" + parser.parse(asTokens(id, comma, id, comma)));
+    assertEquals("[[id], []]", "" + parser.parse(asLexemes(id)));
+    assertEquals("[[id, id], []]", "" + parser.parse(asLexemes(id, comma, id)));
+    assertEquals("[[id], [,]]", "" + parser.parse(asLexemes(id, comma)));
+    assertEquals("[[id, id], [,]]", "" + parser.parse(asLexemes(id, comma, id, comma)));
   }
 }

--- a/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarTestUtil.java
+++ b/grammar/src/test/java/jetbrains/jetpad/grammar/GrammarTestUtil.java
@@ -17,8 +17,8 @@ package jetbrains.jetpad.grammar;
 
 import jetbrains.jetpad.grammar.parser.Lexeme;
 
-public class GrammarTestUtil {
-  public static Lexeme[] asTokens(Terminal... ts) {
+class GrammarTestUtil {
+  static Lexeme[] asLexemes(Terminal... ts) {
     Lexeme[] result = new Lexeme[ts.length];
     for (int i = 0; i < ts.length; i++) {
       result[i] = new Lexeme(ts[i], "" + ts[i]);


### PR DESCRIPTION
Changes against https://github.com/JetBrains/jetpad-projectional/pull/158

* `getLexemeValues()` instead of `getLexemesValues()`

NB Kate please merge no sooner than on Monday