### PR TITLE
complete terminator token

### DIFF
--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/hybridExpr/mapper/ExprHybridEditorSpec.java
@@ -161,7 +161,7 @@ public class ExprHybridEditorSpec extends BaseHybridEditorSpec<Expression> {
   }
 
   @Override
-  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, final Function<Token, Runnable> tokenHandler) {
+  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, Completer completer, final Function<Token, Runnable> tokenHandler) {
     return new CompletionSupplier() {
       @Override
       public List<CompletionItem> get(CompletionParameters cp) {

--- a/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
+++ b/demo/src/main/java/jetbrains/jetpad/projectional/demo/indentDemo/hybrid/LambdaHybridEditorSpec.java
@@ -81,7 +81,7 @@ public class LambdaHybridEditorSpec extends BaseHybridEditorSpec<Expr> {
   }
 
   @Override
-  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, final Function<Token, Runnable> tokenHandler) {
+  public CompletionSupplier getTokenCompletion(CompletionContext completionContext, Completer completer, final Function<Token, Runnable> tokenHandler) {
     return new CompletionSupplier() {
       @Override
       public List<CompletionItem> get(CompletionParameters cp) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseCompleter.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseCompleter.java
@@ -18,13 +18,17 @@ package jetbrains.jetpad.hybrid;
 import jetbrains.jetpad.hybrid.parser.Token;
 
 public abstract class BaseCompleter implements Completer {
+
+  protected BaseCompleter() {
+  }
+
   @Override
   public final Runnable complete(Token token) {
     return complete(new Token[] { token });
   }
 
   @Override
-  public Runnable complete(Token... tokens) {
+  public final Runnable complete(Token... tokens) {
     return complete(tokens.length - 1, tokens);
   }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
@@ -53,8 +53,8 @@ public class SimpleHybridSynchronizer<SourceT> extends BaseHybridSynchronizer<So
       }
 
       @Override
-      public CompletionSupplier getTokenCompletion(CompletionContext completionContext, Function<Token, Runnable> tokenHandler) {
-        return spec.getTokenCompletion(completionContext, tokenHandler);
+      public CompletionSupplier getTokenCompletion(CompletionContext completionContext, Completer completer, Function<Token, Runnable> tokenHandler) {
+        return spec.getTokenCompletion(completionContext, completer, tokenHandler);
       }
 
       @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TerminatorToken.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TerminatorToken.java
@@ -15,18 +15,18 @@
  */
 package jetbrains.jetpad.hybrid;
 
-import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.ValueToken;
 
-public interface Completer {
-  Completer UNSUPPORTED_COMPLETER = new UnsupportedCompleter();
+public final class TerminatorToken<ValueT extends TextValue> extends ValueToken {
 
-  Runnable complete(Token token);
-  Runnable complete(Token... tokens);
+  public TerminatorToken(ValueT val, ValueCloner<ValueT> cloner) {
+    super(val, cloner);
+  }
 
-  /**
-   * @param selectionIndex of the passed token to be selected after the action
-   */
-  Runnable complete(int selectionIndex, Token... tokens);
+  @Override
+  public ValueT value() {
+    //noinspection unchecked
+    return (ValueT) super.value();
+  }
 
-  Runnable completeTerminatorToken(TerminatorToken<?> terminatorToken);
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextValue.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextValue.java
@@ -15,18 +15,8 @@
  */
 package jetbrains.jetpad.hybrid;
 
-import jetbrains.jetpad.hybrid.parser.Token;
+public interface TextValue {
 
-public interface Completer {
-  Completer UNSUPPORTED_COMPLETER = new UnsupportedCompleter();
+  void setText(String text);
 
-  Runnable complete(Token token);
-  Runnable complete(Token... tokens);
-
-  /**
-   * @param selectionIndex of the passed token to be selected after the action
-   */
-  Runnable complete(int selectionIndex, Token... tokens);
-
-  Runnable completeTerminatorToken(TerminatorToken<?> terminatorToken);
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompleter.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompleter.java
@@ -55,7 +55,7 @@ class TokenCompleter {
     return mySync.editorSpec();
   }
 
-  private TokenListEditor<?> getTokeListEditor() {
+  private TokenListEditor<?> getTokenListEditor() {
     return mySync.tokenListEditor();
   }
 
@@ -74,8 +74,8 @@ class TokenCompleter {
         CompletionController controller = placeholder.get(Completion.COMPLETION_CONTROLLER);
         boolean wasActive = controller.isActive();
 
-        getTokeListEditor().tokens.addAll(Arrays.asList(tokens));
-        getTokeListEditor().updateToPrintedTokens();
+        getTokenListEditor().tokens.addAll(Arrays.asList(tokens));
+        getTokenListEditor().updateToPrintedTokens();
 
         Runnable result = getTokenOperations().selectOnCreation(selectionIndex, LAST);
         if (wasActive) {
@@ -113,13 +113,13 @@ class TokenCompleter {
         CompletionController controller = tokenCell.get(Completion.COMPLETION_CONTROLLER);
         final boolean wasCompletionActive = controller != null && controller.isActive();
 
-        getTokeListEditor().tokens.remove(index);
+        getTokenListEditor().tokens.remove(index);
         int i = index;
         for (Token t : tokens) {
-          getTokeListEditor().tokens.add(i++, t);
+          getTokenListEditor().tokens.add(i++, t);
         }
 
-        getTokeListEditor().updateToPrintedTokens();
+        getTokenListEditor().updateToPrintedTokens();
 
         final Cell targetCell =  mySync.tokenCells().get(index + selectionIndex);
         if (!(targetCell instanceof TextCell) || !Objects.equal(((TextCell) targetCell).text().get(), oldText)) {
@@ -157,14 +157,14 @@ class TokenCompleter {
           @Override
           public Runnable complete(int selectionIndex, Token... tokens) {
             int i = index + delta;
-            ObservableList<Token> editorTokenList = getTokeListEditor().tokens;
+            ObservableList<Token> editorTokenList = getTokenListEditor().tokens;
             if (i < editorTokenList.size() && tokens.length >= 1 && tokens[0] instanceof ValueToken && editorTokenList.get(i) instanceof ValueToken) {
               editorTokenList.remove(i);
             }
             for (Token t : tokens) {
               editorTokenList.add(i++, t);
             }
-            getTokeListEditor().updateToPrintedTokens();
+            getTokenListEditor().updateToPrintedTokens();
             Runnable result = getTokenOperations().selectOnCreation(index + delta + selectionIndex, LAST);
             if (cp.isEndRightTransform() && !cp.isMenu()) {
               result = seq(result, activateCompletion(index + delta + selectionIndex));
@@ -312,7 +312,7 @@ class TokenCompleter {
 
     @Override
     public List<Token> getPrefix() {
-      return Collections.unmodifiableList(getTokeListEditor().tokens.subList(0, myTargetIndex));
+      return Collections.unmodifiableList(getTokenListEditor().tokens.subList(0, myTargetIndex));
     }
 
     @Override
@@ -322,17 +322,17 @@ class TokenCompleter {
 
     @Override
     public List<Token> getTokens() {
-      return Collections.unmodifiableList(getTokeListEditor().tokens);
+      return Collections.unmodifiableList(getTokenListEditor().tokens);
     }
 
     @Override
     public Token removeToken(int index) {
-      return getTokeListEditor().tokens.remove(index);
+      return getTokenListEditor().tokens.remove(index);
     }
 
     @Override
     public List<Object> getObjects() {
-      return Collections.unmodifiableList(getTokeListEditor().getObjects());
+      return Collections.unmodifiableList(getTokenListEditor().getObjects());
     }
 
     @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletion.java
@@ -20,5 +20,5 @@ import jetbrains.jetpad.completion.CompletionSupplier;
 import jetbrains.jetpad.hybrid.parser.Token;
 
 public interface TokenCompletion {
-  CompletionSupplier getTokenCompletion(CompletionContext completionContext, Function<Token, Runnable> tokenHandler);
+  CompletionSupplier getTokenCompletion(CompletionContext completionContext, Completer completer, Function<Token, Runnable> tokenHandler);
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/Tokenizer.java
@@ -93,7 +93,7 @@ class Tokenizer {
   private class TextMatcher {
     private final Value<Token> tokenHolder = new Value<>();
     private final CompletionItems completionItems = new CompletionItems(
-        mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, new Function<Token, Runnable>() {
+        mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, Completer.UNSUPPORTED_COMPLETER, new Function<Token, Runnable>() {
           @Nullable
           @Override
           public Runnable apply(@Nullable final Token token) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/UnsupportedCompleter.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/UnsupportedCompleter.java
@@ -1,0 +1,20 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.Token;
+
+final class UnsupportedCompleter extends BaseCompleter {
+
+  UnsupportedCompleter() {
+  }
+
+  @Override
+  public Runnable complete(int selectionIndex, Token... tokens) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Runnable completeTerminatorToken(TerminatorToken<?> terminatorToken) {
+    throw new UnsupportedOperationException();
+  }
+
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/HybridWrapperRole.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/util/HybridWrapperRole.java
@@ -70,10 +70,15 @@ public class HybridWrapperRole<ContainerT, WrapperT, TargetT> implements RoleCom
             sync.setTokens(Arrays.asList(tokens));
             return sync.selectOnCreation(selectionIndex, LAST);
           }
+
+          @Override
+          public Runnable completeTerminatorToken(TerminatorToken<?> terminatorValueToken) {
+            throw new UnsupportedOperationException();
+          }
         };
 
         if (!(cp.isMenu() && myHideTokensInMenu)) {
-          for (CompletionItem ci : mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, new Function<Token, Runnable>() {
+          for (CompletionItem ci : mySpec.getTokenCompletion(CompletionContext.UNSUPPORTED, completer, new Function<Token, Runnable>() {
             @Override
             public Runnable apply(Token input) {
               return completer.complete(input);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/CommentCloner.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/CommentCloner.java
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jetbrains.jetpad.hybrid;
+package jetbrains.jetpad.hybrid.testapp.mapper;
 
-import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.ValueToken;
+import jetbrains.jetpad.hybrid.testapp.model.Comment;
 
-public interface Completer {
-  Completer UNSUPPORTED_COMPLETER = new UnsupportedCompleter();
+final class CommentCloner implements ValueToken.ValueCloner<Comment> {
 
-  Runnable complete(Token token);
-  Runnable complete(Token... tokens);
+  CommentCloner() {
+  }
 
-  /**
-   * @param selectionIndex of the passed token to be selected after the action
-   */
-  Runnable complete(int selectionIndex, Token... tokens);
+  @Override
+  public Comment clone(Comment val) {
+    return new Comment();
+  }
 
-  Runnable completeTerminatorToken(TerminatorToken<?> terminatorToken);
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
 
+  /*
   private static String getText(List<Token> tokenList) {
     StringBuilder builder = new StringBuilder();
     for (Token token : tokenList) {
@@ -38,6 +39,7 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
     }
     return builder.toString();
   }
+  */
 
   private final Token tokenPlus;
   private final Token tokenMul;
@@ -306,7 +308,7 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
   }
 
   @Override
-  public CompletionSupplier getTokenCompletion(final CompletionContext completionContext, final Function<Token, Runnable> tokenHandler) {
+  public CompletionSupplier getTokenCompletion(final CompletionContext completionContext, final Completer completer, final Function<Token, Runnable> tokenHandler) {
     return new CompletionSupplier() {
       @Override
       public List<CompletionItem> get(CompletionParameters cp) {
@@ -355,6 +357,7 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
         result.add(new ByBoundsCompletionItem("#", "") {
           @Override
           public Runnable complete(String text) {
+            /*
             List<Token> tokens = completionContext.getTokens();
             int targetIndex = completionContext.getTargetIndex();
             List<Token> subList = tokens.subList(targetIndex, tokens.size());
@@ -362,10 +365,11 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
             for (int i = 0; i < subList.size(); i++) {
               completionContext.removeToken(targetIndex);
             }
+            */
 
             Comment comment = new Comment();
-            comment.text.set(tokenListText);
-            return tokenHandler.apply(new ValueToken(comment, new ValueExprNodeCloner()));
+            TerminatorToken<?> terminatorToken = new TerminatorToken<>(comment, new CommentCloner());
+            return completer.completeTerminatorToken(terminatorToken);
           }
         });
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/Comment.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/Comment.java
@@ -15,10 +15,11 @@
  */
 package jetbrains.jetpad.hybrid.testapp.model;
 
+import jetbrains.jetpad.hybrid.TextValue;
 import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.ValueProperty;
 
-public class Comment extends ExprNode {
+public class Comment extends ExprNode implements TextValue {
   public Property<String> text = new ValueProperty<>();
 
   public Comment() {
@@ -31,6 +32,11 @@ public class Comment extends ExprNode {
   @Override
   public String toString() {
     return "'#" + text.get() + "'";
+  }
+
+  @Override
+  public void setText(String text) {
+    this.text.set(text);
   }
 
 }


### PR DESCRIPTION
This is an alternative implementation of comment token completion. 
See jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java:370
The commented out code just above is the previous implementation using completionContext.removeToken(). 

Pluses of this implementation:
* Less code for the client
* Will allow to remove modifying removeToken() method from CompletionContext interface.
* Other languages can reuse terminator token for comments and string literals instead of having to implement similar code

There are also updated usages in ot and datapad repos.