### PR TITLE
Completion based tokenizer is now public API

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/CompletionBasedTokenizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/CompletionBasedTokenizer.java
@@ -28,17 +28,21 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
-class Tokenizer {
+public class CompletionBasedTokenizer {
   private final TokenCompletion mySpec;
 
-  Tokenizer(TokenCompletion spec) {
+  public CompletionBasedTokenizer(TokenCompletion spec) {
     mySpec = spec;
   }
 
-  List<Token> tokenize(String input) {
+  public List<Token> tokenize(String input) {
+    return tokenizeSubstring(input, 0, input.length());
+  }
+
+  public List<Token> tokenizeSubstring(String input, int beginIndex, int rightBound) {
     TokensCollector tc = new TokensCollector();
-    for (char currentChar : input.toCharArray()) {
-      tc.append(currentChar);
+    for (int i = beginIndex; i < rightBound; i++) {
+      tc.append(input.charAt(i));
     }
     tc.collectLastToken();
     return tc.tokens;

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenOperations.java
@@ -265,7 +265,7 @@ class TokenOperations<SourceT> {
   }
 
   boolean afterPaste(TextCell textView) {
-    Tokenizer tokenizer = new Tokenizer(mySync.editorSpec());
+    CompletionBasedTokenizer tokenizer = new CompletionBasedTokenizer(mySync.editorSpec());
     List<Token> newTokens = tokenizer.tokenize(textView.text().get());
     int index;
     if (!tokens().isEmpty()) {

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionBasedTokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionBasedTokenizerTest.java
@@ -26,8 +26,8 @@ import static jetbrains.jetpad.hybrid.TokensUtil.*;
 import static jetbrains.jetpad.hybrid.testapp.mapper.Tokens.*;
 import static org.junit.Assert.*;
 
-public class TokenizerTest {
-  private Tokenizer tokenizer = new Tokenizer(new ExprHybridEditorSpec());
+public class CompletionBasedTokenizerTest {
+  private CompletionBasedTokenizer tokenizer = new CompletionBasedTokenizer(new ExprHybridEditorSpec());
 
   @Test
   public void oneToken() {
@@ -102,6 +102,18 @@ public class TokenizerTest {
     assertTokensEqual(of(LP, integer(10), RP, MUL, integer(5), FACTORIAL, PLUS, ID, DOT, value(), INCREMENT, PLUS,
         singleQtd("\"text 1\""), PLUS, doubleQtd("text 2")),
         tokens);
+  }
+
+  @Test
+  public void tokenizeSubstringWithWholeTokens() {
+    List<Token> tokens = tokenizer.tokenizeSubstring("1 + 2 + 3", 2, 6);
+    assertTokensEqual(of(PLUS, integer(2)), tokens);
+  }
+
+  @Test
+  public void tokenizeSubstringWithTokenParts() {
+    List<Token> tokens = tokenizer.tokenizeSubstring("123 + 789", 2, 8);
+    assertTokensEqual(of(integer(3), PLUS, integer(78)), tokens);
   }
 
   @Test


### PR DESCRIPTION
Needed to use tokenizer outside a package. Besides, added useful method to tokenize a substring — so doing you can skip something in the line beginning or end.