### PR TITLE
Extracted tokens joining to public util

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -34,6 +34,7 @@ import jetbrains.jetpad.cell.trait.DerivedCellTrait;
 import jetbrains.jetpad.cell.util.*;
 import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.TokenUtil;
 import jetbrains.jetpad.hybrid.parser.ValueToken;
 import jetbrains.jetpad.hybrid.parser.prettyprint.ParseNode;
 import jetbrains.jetpad.hybrid.parser.prettyprint.ParseNodes;
@@ -322,22 +323,11 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
 
           @Override
           public String toString() {
-            StringBuilder joinedTokens = new StringBuilder();
-            Token prevToken = null;
-            for (Token currToken : tokens) {
-              if (prevToken != null && !prevToken.noSpaceToRight() && !currToken.noSpaceToLeft()) {
-                joinedTokens.append(' ');
-              }
-              String currText;
-              try {
-                currText = currToken.text();
-              } catch (UnsupportedOperationException e) {
-                return super.toString();
-              }
-              joinedTokens.append(currText);
-              prevToken = currToken;
+            try {
+              return TokenUtil.join(tokens);
+            } catch (UnsupportedOperationException e) {
+              return super.toString();
             }
-            return joinedTokens.toString();
           }
         };
       }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/TokenUtil.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/TokenUtil.java
@@ -1,0 +1,22 @@
+package jetbrains.jetpad.hybrid.parser;
+
+import java.util.List;
+
+public class TokenUtil {
+  public static String join(List<Token> tokens) {
+    StringBuilder joined = new StringBuilder();
+    Token prevToken = null;
+    for (Token currToken : tokens) {
+      if (prevToken != null && !prevToken.noSpaceToRight() && !currToken.noSpaceToLeft()) {
+        joined.append(' ');
+      }
+      // NB: Token.text() may throw UnsupportedOperationException
+      joined.append(currToken.text());
+      prevToken = currToken;
+    }
+    return joined.toString();
+  }
+
+  private TokenUtil() {
+  }
+}


### PR DESCRIPTION
This util-class can be useful outside hybrid editor, so I extracted it out.

Why `TokenUtil` and not `Tokens`: some tests and apps have already classes like `Tokens` or `...Tokens` which have all tokens as static fields, so I chose another naming pattern.