### PR TITLE
remove TokenListEditor from public API; get rid of hybrid.util package

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridSynchronizer.java
@@ -23,7 +23,6 @@ import jetbrains.jetpad.cell.util.CellStateDifference;
 import jetbrains.jetpad.cell.util.CellStateHandler;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.mapper.Mapper;
-import jetbrains.jetpad.model.collections.CollectionListener;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
 import jetbrains.jetpad.model.event.CompositeRegistration;
 import jetbrains.jetpad.model.event.EventHandler;
@@ -37,23 +36,22 @@ public class HybridSynchronizer<SourceT> extends BaseHybridSynchronizer<SourceT,
   private Property<SourceT> myWritableSource;
 
   public HybridSynchronizer(Mapper<?, ?> contextMapper, Property<SourceT> source, Cell target,
-      HybridEditorSpec<SourceT> spec) {
+                            HybridEditorSpec<SourceT> spec) {
     this(contextMapper, source, target, Properties.constant(spec));
   }
 
   public HybridSynchronizer(Mapper<?, ?> contextMapper, Property<SourceT> source, Cell target,
-      ReadableProperty<HybridEditorSpec<SourceT>> spec) {
+                            ReadableProperty<HybridEditorSpec<SourceT>> spec) {
     super(contextMapper, source, target, spec, new TokenListEditor<>(spec, new ObservableArrayList<Token>(), true));
     myWritableSource = source;
   }
 
   @Override
-  protected Registration onAttach(CollectionListener<Token> tokensListener) {
+  protected Registration onAttach(Property<SourceT> syncValue) {
     updateTargetError();
     return new CompositeRegistration(
-      PropertyBinding.bindTwoWay(myWritableSource, myTokenListEditor.value),
-      myTokenListEditor.tokens.addListener(tokensListener),
-      myTokenListEditor.valid.addHandler(new EventHandler<PropertyChangeEvent<Boolean>>() {
+      PropertyBinding.bindTwoWay(myWritableSource, syncValue),
+      valid().addHandler(new EventHandler<PropertyChangeEvent<Boolean>>() {
         @Override
         public void onEvent(PropertyChangeEvent<Boolean> event) {
           updateTargetError();
@@ -90,7 +88,7 @@ public class HybridSynchronizer<SourceT> extends BaseHybridSynchronizer<SourceT,
   }
 
   private void updateTargetError() {
-    MessageController.setError(getTarget(), myTokenListEditor.valid.get() ? null : "parsing error");
+    MessageController.setError(getTarget(), valid().get() ? null : "parsing error");
   }
 
   private static class HybridCellState implements CellState {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jetbrains.jetpad.hybrid.util;
+package jetbrains.jetpad.hybrid;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.completion.*;
-import jetbrains.jetpad.hybrid.*;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.mapper.Mapper;
 import jetbrains.jetpad.projectional.generic.Role;
@@ -31,22 +30,23 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static jetbrains.jetpad.hybrid.SelectionPosition.*;
+import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
 
-public class HybridWrapperRole<ContainerT, WrapperT, TargetT> implements RoleCompletion<ContainerT, WrapperT> {
+public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implements RoleCompletion<ContainerT, WrapperT> {
   private SimpleHybridEditorSpec<TargetT> mySpec;
   private Supplier<WrapperT> myFactory;
   private Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> mySyncProvider;
   private boolean myHideTokensInMenu;
 
 
-  public HybridWrapperRole(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
-      Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider) {
+  public HybridWrapperRoleCompletion(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
+                                     Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider) {
     this(spec, targetFactory, syncProvider, false);
   }
 
-  public HybridWrapperRole(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
-      Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider, boolean hideTokensInMenus) {
+  public HybridWrapperRoleCompletion(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
+                                     Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider,
+                                     boolean hideTokensInMenus) {
     mySpec = spec;
     myFactory = targetFactory;
     mySyncProvider = syncProvider;

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridProperty.java
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jetbrains.jetpad.hybrid.util;
+package jetbrains.jetpad.hybrid;
 
 import jetbrains.jetpad.base.Registration;
-import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.parser.Parser;
 import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridSynchronizer.java
@@ -27,14 +27,15 @@ import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinter;
 import jetbrains.jetpad.mapper.Mapper;
-import jetbrains.jetpad.model.collections.CollectionListener;
 import jetbrains.jetpad.model.event.CompositeRegistration;
 import jetbrains.jetpad.model.event.EventHandler;
 import jetbrains.jetpad.model.property.Properties;
+import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.PropertyBinding;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
 public class SimpleHybridSynchronizer<SourceT> extends BaseHybridSynchronizer<SourceT, SimpleHybridEditorSpec<SourceT>> {
+
   private static <SourceT> HybridEditorSpec<SourceT> toHybridEditorSpec(final SimpleHybridEditorSpec<SourceT> spec) {
     return new HybridEditorSpec<SourceT>() {
       @Override
@@ -77,13 +78,12 @@ public class SimpleHybridSynchronizer<SourceT> extends BaseHybridSynchronizer<So
     super(contextMapper, source, target, Properties.constant(spec),
       new TokenListEditor<>(toHybridEditorSpec(spec), source.getTokens(), false));
   }
-  
+
   @Override
-  protected Registration onAttach(CollectionListener<Token> tokensListener) {
+  protected Registration onAttach(Property<SourceT> syncValue) {
     updateTargetError();
     return new CompositeRegistration(
-      PropertyBinding.bindOneWay(getSource(), myTokenListEditor.value),
-      myTokenListEditor.tokens.addListener(tokensListener),
+      PropertyBinding.bindOneWay(getSource(), syncValue),
       Properties.isNull(getSource()).addHandler(new EventHandler<PropertyChangeEvent<Boolean>>() {
         @Override
         public void onEvent(PropertyChangeEvent<Boolean> event) {

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -34,7 +34,6 @@ import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.hybrid.parser.*;
 import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
 import jetbrains.jetpad.hybrid.testapp.model.*;
-import jetbrains.jetpad.hybrid.util.HybridWrapperRole;
 import jetbrains.jetpad.mapper.Mapper;
 import jetbrains.jetpad.model.composite.Composites;
 import jetbrains.jetpad.projectional.util.RootController;
@@ -45,7 +44,8 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static jetbrains.jetpad.hybrid.SelectionPosition.*;
+import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
+import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
 import static jetbrains.jetpad.hybrid.TokensUtil.*;
 import static org.junit.Assert.*;
 
@@ -1005,7 +1005,7 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
 
   @Test
   public void hideTokensInMenuForHybridWrapperRole() {
-    HybridWrapperRole<Object, Expr, Expr> hybridWrapperRole = new HybridWrapperRole<>(getSpec(), null, null, true);
+    HybridWrapperRoleCompletion<Object, Expr, Expr> hybridWrapperRole = new HybridWrapperRoleCompletion<>(getSpec(), null, null, true);
     CompletionSupplier roleCompletion = hybridWrapperRole.createRoleCompletion(mapper, null, null);
     CompletionParameters completionParameters = new BaseCompletionParameters() {
       @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridPropertyTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridPropertyTest.java
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package jetbrains.jetpad.hybrid.util;
+package jetbrains.jetpad.hybrid;
 
-import jetbrains.jetpad.hybrid.HybridEditorSpec;
-import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.parser.ErrorToken;
 import jetbrains.jetpad.hybrid.parser.IdentifierToken;
 import jetbrains.jetpad.hybrid.parser.Token;
@@ -30,7 +28,8 @@ import jetbrains.jetpad.test.BaseTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class SimpleHybridPropertyTest extends BaseTestCase {
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
@@ -1,10 +1,10 @@
 package jetbrains.jetpad.hybrid.testapp.model;
 
 import jetbrains.jetpad.hybrid.HybridProperty;
+import jetbrains.jetpad.hybrid.SimpleHybridProperty;
 import jetbrains.jetpad.hybrid.parser.SimpleParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
-import jetbrains.jetpad.hybrid.util.SimpleHybridProperty;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
 
 public class SimpleExprContainer extends ExprNode {


### PR DESCRIPTION
I'd also like to remove BaseHybridSynchronizer from public API via replacing it with HybridSynchronizer interface, but not now.
There are corresponding pull requests to ot and datapad:
https://github.com/JetBrains/jetpad-ot/pull/50
https://github.com/JetBrains/datapad/pull/6