### PR TITLE
Exracted getting text of tokens list to public util

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -37,6 +37,7 @@ import jetbrains.jetpad.cell.util.CellState;
 import jetbrains.jetpad.cell.util.CellStateHandler;
 import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.TokenUtil;
 import jetbrains.jetpad.hybrid.parser.ValueToken;
 import jetbrains.jetpad.hybrid.parser.prettyprint.ParseNode;
 import jetbrains.jetpad.hybrid.parser.prettyprint.ParseNodes;
@@ -331,22 +332,11 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
 
           @Override
           public String toString() {
-            StringBuilder joinedTokens = new StringBuilder();
-            Token prevToken = null;
-            for (Token currToken : tokens) {
-              if (prevToken != null && !prevToken.noSpaceToRight() && !currToken.noSpaceToLeft()) {
-                joinedTokens.append(' ');
-              }
-              String currText;
-              try {
-                currText = currToken.text();
-              } catch (UnsupportedOperationException e) {
-                return super.toString();
-              }
-              joinedTokens.append(currText);
-              prevToken = currToken;
+            try {
+              return TokenUtil.getText(tokens);
+            } catch (UnsupportedOperationException e) {
+              return super.toString();
             }
-            return joinedTokens.toString();
           }
         };
       }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/TokenUtil.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/parser/TokenUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid.parser;
+
+import java.util.List;
+
+public class TokenUtil {
+  public static String getText(List<Token> tokens) {
+    StringBuilder text = new StringBuilder();
+    Token prevToken = null;
+    for (Token currToken : tokens) {
+      if (prevToken != null && !prevToken.noSpaceToRight() && !currToken.noSpaceToLeft()) {
+        text.append(' ');
+      }
+      // NB: Token.text() may throw UnsupportedOperationException
+      text.append(currToken.text());
+      prevToken = currToken;
+    }
+    return text.toString();
+  }
+
+  private TokenUtil() {
+  }
+}


### PR DESCRIPTION
Changes since https://github.com/JetBrains/jetpad-projectional/pull/166

* Renamed `join()` to `getText()`, like in `jetbrains.jetpad.hybrid.TokenCompleter`
* Renamed local variable `joined` to `text`
* Added license text to the file header
