### PR TITLE
Bulk completion of pasted text

### DIFF
--- a/cell/src/test/java/jetbrains/jetpad/cell/completion/CompletionTestCase.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/completion/CompletionTestCase.java
@@ -25,13 +25,13 @@ import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
 import jetbrains.jetpad.completion.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 public abstract class CompletionTestCase extends EditingTestCase {
-  private String mySetTo;
+  private List<String> mySetTo = new ArrayList<>();
 
   protected CompletionSupplier createCompletion(final String... items) {
     return new CompletionSupplier() {
@@ -84,12 +84,12 @@ public abstract class CompletionTestCase extends EditingTestCase {
     return result;
   }
 
-  protected void assertCompleted(String text) {
-    assertEquals(text, mySetTo);
+  protected void assertCompleted(String ... text) {
+    assertEquals(Arrays.asList(text), mySetTo);
   }
 
   protected void assertNotCompleted() {
-    assertNull(mySetTo);
+    assertEquals(0, mySetTo.size());
   }
 
   protected class SetTextToCompletionItem extends SimpleCompletionItem {
@@ -106,7 +106,7 @@ public abstract class CompletionTestCase extends EditingTestCase {
 
     @Override
     public Runnable complete(String text) {
-      mySetTo = myCompletion;
+      mySetTo.add(myCompletion);
       return Runnables.EMPTY;
     }
   }

--- a/completion/src/main/java/jetbrains/jetpad/completion/BaseCompletionParameters.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/BaseCompletionParameters.java
@@ -25,4 +25,9 @@ public class BaseCompletionParameters implements CompletionParameters {
   public boolean isMenu() {
     return false;
   }
+
+  @Override
+  public boolean isBulkCompletionRequired() {
+    return false;
+  }
 }

--- a/completion/src/main/java/jetbrains/jetpad/completion/CompletionParameters.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/CompletionParameters.java
@@ -16,8 +16,10 @@
 package jetbrains.jetpad.completion;
 
 public interface CompletionParameters {
-  static final CompletionParameters EMPTY = new BaseCompletionParameters();
+  CompletionParameters EMPTY = new BaseCompletionParameters();
 
   boolean isEndRightTransform();
   boolean isMenu();
+
+  boolean isBulkCompletionRequired();
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.hybrid;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
@@ -33,6 +34,10 @@ import java.util.List;
 import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
 
 public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implements RoleCompletion<ContainerT, WrapperT> {
+  private static boolean isNotBlank(String string) {
+    return CharMatcher.whitespace().negate().matchesAnyOf(string);
+  }
+
   private SimpleHybridEditorSpec<TargetT> mySpec;
   private Supplier<WrapperT> myFactory;
   private Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> mySyncProvider;
@@ -40,13 +45,13 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
 
 
   public HybridWrapperRoleCompletion(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
-                                     Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider) {
+      Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider) {
     this(spec, targetFactory, syncProvider, false);
   }
 
   public HybridWrapperRoleCompletion(SimpleHybridEditorSpec<TargetT> spec, Supplier<WrapperT> targetFactory,
-                                     Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider,
-                                     boolean hideTokensInMenus) {
+      Function<Mapper<?, ?>, ? extends BaseHybridSynchronizer<TargetT, ?>> syncProvider,
+      boolean hideTokensInMenus) {
     mySpec = spec;
     myFactory = targetFactory;
     mySyncProvider = syncProvider;
@@ -77,60 +82,93 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
           }
         };
 
-        if (!(cp.isMenu() && myHideTokensInMenu)) {
-          for (CompletionItem ci : mySpec.getTokenCompletion(completer, new Function<Token, Runnable>() {
+        if (cp.isBulkCompletionRequired()) {
+          result.add(new BaseCompletionItem() {
             @Override
-            public Runnable apply(Token input) {
-              return completer.complete(input);
+            public String visibleText(String text) {
+              throw new IllegalStateException("This completion item must not be visible");
             }
-          }).get(cp)) {
-            result.add(new WrapperCompletionItem(ci) {
+
+            @Override
+            public boolean isStrictMatchPrefix(String text) {
+              return !isMatch(text);
+            }
+
+            @Override
+            public boolean isMatch(String text) {
+              return isNotBlank(text);
+            }
+
+            @Override
+            public Runnable complete(final String text) {
+              return new Runnable() {
+                @Override
+                public void run() {
+                  CompletionTokenizer tokenizer = new CompletionTokenizer(mySpec);
+                  List<Token> tokens = tokenizer.tokenize(text);
+                  if (!tokens.isEmpty()) {
+                    completer.complete(tokens.toArray(new Token[tokens.size()])).run();
+                  }
+                }
+              };
+            }
+          });
+        } else {
+          if (!(cp.isMenu() && myHideTokensInMenu)) {
+            for (CompletionItem ci : mySpec.getTokenCompletion(completer, new Function<Token, Runnable>() {
               @Override
-              public boolean isLowMatchPriority() {
-                return true;
+              public Runnable apply(Token input) {
+                return completer.complete(input);
               }
-            });
+            }).get(cp)) {
+              result.add(new WrapperCompletionItem(ci) {
+                @Override
+                public boolean isLowMatchPriority() {
+                  return true;
+                }
+              });
+            }
           }
-        }
 
-        if (cp.isMenu()) {
-          CompletionSupplier compl = mySpec.getAdditionalCompletion(new CompletionContext() {
-            @Override
-            public int getTargetIndex() {
-              return 0;
-            }
+          if (cp.isMenu()) {
+            CompletionSupplier compl = mySpec.getAdditionalCompletion(new CompletionContext() {
+              @Override
+              public int getTargetIndex() {
+                return 0;
+              }
 
-            @Override
-            public List<Token> getPrefix() {
-              return Collections.emptyList();
-            }
+              @Override
+              public List<Token> getPrefix() {
+                return Collections.emptyList();
+              }
 
-            @Override
-            public List<Cell> getViews() {
-              return Collections.emptyList();
-            }
+              @Override
+              public List<Cell> getViews() {
+                return Collections.emptyList();
+              }
 
-            @Override
-            public List<Token> getTokens() {
-              return Collections.emptyList();
-            }
+              @Override
+              public List<Token> getTokens() {
+                return Collections.emptyList();
+              }
 
-            @Override
-            public List<Object> getObjects() {
-              return Collections.emptyList();
-            }
+              @Override
+              public List<Object> getObjects() {
+                return Collections.emptyList();
+              }
 
-            @Override
-            public Mapper<?, ?> getContextMapper() {
-              return mapper;
-            }
+              @Override
+              public Mapper<?, ?> getContextMapper() {
+                return mapper;
+              }
 
-            @Override
-            public Object getTarget() {
-              return target.get();
-            }
-          }, completer);
-          result.addAll(FluentIterable.from(compl.get(new BaseCompletionParameters())).toList());
+              @Override
+              public Object getTarget() {
+                return target.get();
+              }
+            }, completer);
+            result.addAll(FluentIterable.from(compl.get(new BaseCompletionParameters())).toList());
+          }
         }
         return result;
       }


### PR DESCRIPTION
The "bulk completion" is completing some long input against number of simple completion items. Technically, it's an option asking a `CompletionSupplier` to include such a completion item which can split an input and complete each part one by one. We need this to support textual paste in Cells which do not have hybrid synchronizers intially but create it upon first matching completion (for example, id, or number). Such cells to not have `TokenEditor` and can't benefit from `TokenOperations.afterPaste()`. As this "lazy-hybrid-creation" behaviour is supported in `HybridWrapperRoleCompletion`, I added bulk completion support into this class.

NB possible conflict with https://github.com/JetBrains/jetpad-projectional/pull/176