### PR TITLE
Projectional synchronizer can support ClipboardContent of different kind

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -181,16 +181,13 @@ public class TextEditingTrait extends TextNavigationTrait {
 
     String text = content.get(ContentKinds.TEXT);
 
-    StringBuilder newText = new StringBuilder();
-    for (int i = 0; i < text.length(); i++) {
-      if (text.charAt(i) != '\n') {
-        newText.append(text.charAt(i));
-      }
+    if (text.contains("\n") || text.contains("\r")) {
+      return;
     }
 
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     clearSelection(editor);
-    pasteText(editor, newText.toString());
+    pasteText(editor, text);
     onAfterPaste(editor);
     event.consume();
   }

--- a/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
@@ -567,11 +567,11 @@ public class TextEditingTest extends EditingTestCase {
   }
 
   @Test
-  public void textPasteFiltersNewLines() {
-    textView.text().set("");
+  public void textPasteRejectsMultilineString() {
+    textView.text().set("a");
     textView.caretPosition().set(0);
 
-    paste("\na");
+    paste("\nb");
 
     assertEquals("a", textView.text().get());
   }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -28,6 +28,12 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void setCompletion(RoleCompletion<? super ContextT, SourceT> completion);
   void setDeleteHandler(DeleteHandler handler);
   void setClipboardParameters(ContentKind<SourceT> kind, Function<SourceT, SourceT> cloner);
+  <ContentT> void supportContentKind(ContentKind<ContentT> kind,
+      Function<ContentT, SourceT> fromKind,
+      Function<SourceT, ContentT> toKind);
+  <ContentT> void supportContentKindCompatibleToItemsList(ContentKind<ContentT> kind,
+      Function<ContentT, List<SourceT>> fromKind,
+      Function<List<SourceT>, ContentT> toKind);
   void setOnLastItemDeleted(Runnable action);
   void setPlaceholderText(String text);
   void setItemFactory(Supplier<SourceT> itemFactory);


### PR DESCRIPTION
NB: depends on https://github.com/JetBrains/jetpad-mapper/pull/69.

The main goal is to support textual content kind. For this purpose, client must provide two functions: from-another-content-kind (parser), and to-another-content-kind (text-generator). This also makes it possible pasting from Hybrid Synchronizer, for this client must provide parser which reads tokens.

The biggest functional impact is in `TextEditingTrait` on multiline input. Earlier newlines were removed from pasted text, now such text is rejected. As removing newlines seems to be sort of fallback and something that almost always leads to syntactically incorrect input, I suppose it's OK to drop it. Not dropping it causes to create some try-rollback-retry events handling strategy, e.g. we paste to Hybrid, if it's syntactically incorrect paste to Projectional, but if it also doesn't accept it, remove newlines and try again. It's too complex and hardly is really needed.
