### PR TITLE
Changed TOKENS_CONTENT constant visibility to public

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -69,7 +69,7 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
 
   static final CellTraitPropertySpec<HybridSynchronizer<?>> HYBRID_SYNCHRONIZER = new CellTraitPropertySpec<>("hybridSynchronizer");
 
-  private static final ContentKind<List<Token>> TOKENS_CONTENT = new ContentKind<List<Token>>() {};
+  public static final ContentKind<List<Token>> TOKENS_CONTENT = new ContentKind<List<Token>>() {};
 
   private TokenListEditor<SourceT> myTokenListEditor;
 


### PR DESCRIPTION
Related to (but does not depend on) https://github.com/JetBrains/jetpad-projectional/pull/185

This is a prerequisite to implement clipboard content interchanges between projectional and hybrid editors. The client code is expected to use this constant when adjusting projectional synchronizer.