### PR TITLE
Projectional synchronizer can support ClipboardContents of different kinds

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
@@ -216,8 +216,8 @@ public class CellContainer {
 
   private void setContent(CopyCutEvent e) {
     myContent = e.getResult();
-    if (myContent.isSupported(ContentKinds.TEXT)) {
-      myLastSeenText = myContent.get(ContentKinds.TEXT);
+    if (myContent.isSupported(ContentKinds.ANY_TEXT)) {
+      myLastSeenText = myContent.get(ContentKinds.ANY_TEXT);
     } else {
       myLastSeenText = myContent.toString();
     }
@@ -225,7 +225,7 @@ public class CellContainer {
 
   public void paste(String text) {
     if (!Objects.equal(myLastSeenText, text)) {
-      myContent = new TextClipboardContent(text);
+      myContent = TextContentHelper.createClipboardContent(text);
       myLastSeenText = text;
     }
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -177,20 +177,11 @@ public class TextEditingTrait extends TextNavigationTrait {
   @Override
   public void onPaste(Cell cell, PasteEvent event) {
     ClipboardContent content = event.getContent();
-    if (!content.isSupported(ContentKinds.TEXT)) return;
-
-    String text = content.get(ContentKinds.TEXT);
-
-    StringBuilder newText = new StringBuilder();
-    for (int i = 0; i < text.length(); i++) {
-      if (text.charAt(i) != '\n') {
-        newText.append(text.charAt(i));
-      }
-    }
+    if (!content.isSupported(ContentKinds.SINGLE_LINE_TEXT)) return;
 
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     clearSelection(editor);
-    pasteText(editor, newText.toString());
+    pasteText(editor, content.get(ContentKinds.SINGLE_LINE_TEXT));
     onAfterPaste(editor);
     event.consume();
   }
@@ -213,7 +204,7 @@ public class TextEditingTrait extends TextNavigationTrait {
     if (from == to) return;
 
     String selection = editor.text().get().substring(from, to);
-    event.consume(new TextClipboardContent(selection));
+    event.consume(TextContentHelper.createClipboardContent(selection));
   }
 
   private void pasteText(CellTextEditor editor, String text) {

--- a/cell/src/main/java/jetbrains/jetpad/cell/toView/CellContainerToViewMapper.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/toView/CellContainerToViewMapper.java
@@ -316,8 +316,8 @@ public class CellContainerToViewMapper extends Mapper<CellContainer, View> {
         @Override
         public void handle(View view, PasteEvent e) {
           ClipboardContent content = e.getContent();
-          if (content.isSupported(ContentKinds.TEXT)) {
-            cellContainer.paste(content.get(ContentKinds.TEXT));
+          if (content.isSupported(ContentKinds.ANY_TEXT)) {
+            cellContainer.paste(content.get(ContentKinds.ANY_TEXT));
             e.consume();
           }
         }

--- a/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/text/TextEditingTest.java
@@ -567,11 +567,11 @@ public class TextEditingTest extends EditingTestCase {
   }
 
   @Test
-  public void textPasteFiltersNewLines() {
-    textView.text().set("");
+  public void textPasteRejectsMultilineString() {
+    textView.text().set("a");
     textView.caretPosition().set(0);
 
-    paste("\na");
+    paste("\nb");
 
     assertEquals("a", textView.text().get());
   }
@@ -588,8 +588,8 @@ public class TextEditingTest extends EditingTestCase {
 
     ClipboardContent result = event.getResult();
     assertTrue(event.isConsumed());
-    assertTrue(result.isSupported(ContentKinds.TEXT));
-    assertEquals("y", result.get(ContentKinds.TEXT));
+    assertTrue(result.isSupported(ContentKinds.SINGLE_LINE_TEXT));
+    assertEquals("y", result.get(ContentKinds.SINGLE_LINE_TEXT));
   }
 
   @Test
@@ -604,8 +604,8 @@ public class TextEditingTest extends EditingTestCase {
     ClipboardContent result = event.getResult();
 
     assertTrue(event.isConsumed());
-    assertTrue(result.isSupported(ContentKinds.TEXT));
-    assertEquals("y", result.get(ContentKinds.TEXT));
+    assertTrue(result.isSupported(ContentKinds.SINGLE_LINE_TEXT));
+    assertEquals("y", result.get(ContentKinds.SINGLE_LINE_TEXT));
     assertEquals("xz", textView.text().get());
     assertEquals(1, (int) textView.caretPosition().get());
     assertFalse(textView.selectionVisible().get());

--- a/event/src/main/java/jetbrains/jetpad/event/ContentKinds.java
+++ b/event/src/main/java/jetbrains/jetpad/event/ContentKinds.java
@@ -18,7 +18,9 @@ package jetbrains.jetpad.event;
 import java.util.List;
 
 public class ContentKinds {
-  public static final ContentKind<String> TEXT = create("text");
+  public static final ContentKind<String> SINGLE_LINE_TEXT = create("singleLineText");
+  public static final ContentKind<Iterable<String>> MULTILINE_TEXT = create("multilineText");
+  public static final ContentKind<String> ANY_TEXT = create("anyText");
 
   public static <T> ContentKind<T> create(final String name) {
     return new ContentKind<T>() {

--- a/event/src/main/java/jetbrains/jetpad/event/MultilineTextClipboardContent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/MultilineTextClipboardContent.java
@@ -15,26 +15,25 @@
  */
 package jetbrains.jetpad.event;
 
-public class TextClipboardContent implements ClipboardContent {
-  private String myText;
+import static jetbrains.jetpad.event.ContentKinds.*;
 
-  public TextClipboardContent(String text) {
-    myText = text;
+class MultilineTextClipboardContent implements ClipboardContent {
+  private Iterable<String> myLines;
+
+  MultilineTextClipboardContent(Iterable<String> text) {
+    myLines = text;
   }
 
   @Override
   public boolean isSupported(ContentKind<?> kind) {
-    return kind == ContentKinds.TEXT;
+    return kind == MULTILINE_TEXT || kind == ANY_TEXT;
   }
 
   @Override
   public <T> T get(ContentKind<T> kind) {
-    if (kind == ContentKinds.TEXT) return (T) myText;
+    if (kind == MULTILINE_TEXT) return (T) myLines;
+    if (kind == ANY_TEXT) return (T) TextContentHelper.joinLines(myLines);
 
     throw new IllegalArgumentException();
-  }
-
-  public String getText() {
-    return myText;
   }
 }

--- a/event/src/main/java/jetbrains/jetpad/event/SingleLineTextClipboardContent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/SingleLineTextClipboardContent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.event;
+
+import static jetbrains.jetpad.event.ContentKinds.ANY_TEXT;
+
+class SingleLineTextClipboardContent implements ClipboardContent {
+  private String myText;
+
+  SingleLineTextClipboardContent(String text) {
+    myText = text;
+  }
+
+  @Override
+  public boolean isSupported(ContentKind<?> kind) {
+    return kind == ContentKinds.SINGLE_LINE_TEXT || kind == ANY_TEXT;
+  }
+
+  @Override
+  public <T> T get(ContentKind<T> kind) {
+    if (kind == ContentKinds.SINGLE_LINE_TEXT || kind == ANY_TEXT) return (T) myText;
+
+    throw new IllegalArgumentException();
+  }
+}

--- a/event/src/main/java/jetbrains/jetpad/event/TextContentHelper.java
+++ b/event/src/main/java/jetbrains/jetpad/event/TextContentHelper.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.event;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+public class TextContentHelper {
+  private static final char CR = '\r';
+  private static final char LF = '\n';
+
+  public static ClipboardContent createClipboardContent(String string) {
+    if (string.indexOf(LF) != -1 || string.indexOf(CR) != -1) {
+      return new MultilineTextClipboardContent(splitByNewline(string));
+    }
+    return new SingleLineTextClipboardContent(string);
+  }
+
+  public static Iterable<String> splitByNewline(final String multiline) {
+    return new Iterable<String>() {
+      @Override
+      public Iterator<String> iterator() {
+        return new LinesIterator(multiline);
+      }
+    };
+  }
+
+  public static String joinLines(Iterable<String> lines) {
+    StringBuilder multiline = new StringBuilder();
+    for (String line : lines) {
+      multiline.append(line).append('\n');
+    }
+    return multiline.toString();
+  }
+
+  // Recognized EOL sequences: \r, \n, \r\n, \n\r
+  private static class LinesIterator implements Iterator<String> {
+    private final String myMultiline;
+    private int myCurrentPos;
+
+    private LinesIterator(String multiline) {
+      this.myMultiline = multiline;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !lookingAtEOF();
+    }
+
+    @Override
+    public String next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+      int lineBeginning = myCurrentPos;
+      advancePastStringBody();
+      int lineRightBound = myCurrentPos;
+      if (!lookingAtEOF()) {
+        advancePastNewline();
+      }
+      return myMultiline.substring(lineBeginning, lineRightBound);
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+
+    private void advancePastStringBody() {
+      while (lookingAtStringBody()) {
+        advance();
+      }
+    }
+
+    private void advancePastNewline() {
+      if (!tryAdvancePast(CR, LF)) {
+        if (!tryAdvancePast(LF, CR)) {
+          throw new IllegalStateException();
+        }
+      }
+    }
+
+    private boolean tryAdvancePast(char required, char optional) {
+      if (current() == required) {
+        advance();
+        if (!lookingAtEOF() && current() == optional) {
+          advance();
+        }
+        return true;
+      }
+      return false;
+    }
+
+    private char current() {
+      return myMultiline.charAt(myCurrentPos);
+    }
+
+    private void advance() {
+      myCurrentPos++;
+    }
+
+    private boolean lookingAtStringBody() {
+      return !lookingAtEOF() && current() != CR && current() != LF;
+    }
+
+    private boolean lookingAtEOF() {
+      return myCurrentPos == myMultiline.length();
+    }
+  }
+}

--- a/event/src/main/java/jetbrains/jetpad/event/dom/ClipboardSupport.java
+++ b/event/src/main/java/jetbrains/jetpad/event/dom/ClipboardSupport.java
@@ -46,10 +46,10 @@ public class ClipboardSupport {
     }.schedule(20);
   }
 
-  public void copyContent(ClipboardContent content ) {
+  public void copyContent(ClipboardContent content) {
     final TextArea copyArea = createClipboardTextArea();
-    if (content.isSupported(ContentKinds.TEXT)) {
-      copyArea.setText(content.get(ContentKinds.TEXT));
+    if (content.isSupported(ContentKinds.ANY_TEXT)) {
+      copyArea.setText(content.get(ContentKinds.ANY_TEXT));
     } else {
       copyArea.setText(content.toString());
     }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.projectional.cell;
 
 import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.base.Objects;
 import com.google.common.base.Supplier;
 import jetbrains.jetpad.base.Registration;
@@ -46,12 +47,15 @@ import jetbrains.jetpad.model.event.EventHandler;
 import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 import jetbrains.jetpad.model.property.ValueProperty;
+import jetbrains.jetpad.model.util.ListMap;
 import jetbrains.jetpad.projectional.generic.EmptyRoleCompletion;
 import jetbrains.jetpad.projectional.generic.Role;
 import jetbrains.jetpad.projectional.generic.RoleCompletion;
 import jetbrains.jetpad.values.Color;
 
 import java.util.*;
+
+import static jetbrains.jetpad.event.ContentKinds.listOf;
 
 abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> implements ProjectionalRoleSynchronizer<ContextT, SourceItemT> {
   private RoleSynchronizer<SourceItemT, Cell> myRoleSynchronizer;
@@ -66,6 +70,10 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   private DeleteHandler myDeleteHandler = DeleteHandler.EMPTY;
   private ContentKind<SourceItemT> myItemKind;
   private Function<SourceItemT, SourceItemT> myCloner;
+  private Function<SourceItemT, String> myContentToString;
+  private Function<List<SourceItemT>, String> myContentListToString;
+  private ListMap<ContentKind, Function<?, SourceItemT>> myContentKinds = new ListMap<>();
+  private ListMap<ContentKind, Function<?, List<SourceItemT>>> myListContentKinds = new ListMap<>();
   private Runnable myOnLastItemDeleted;
   private List<Cell> myTargetList;
   private List<Registration> myRegistrations;
@@ -173,6 +181,36 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   public void setClipboardParameters(ContentKind<SourceItemT> kind, Function<SourceItemT, SourceItemT> cloner) {
     myItemKind = kind;
     myCloner = cloner;
+    myContentKinds.put(kind, Functions.<SourceItemT>identity());
+  }
+
+  @Override
+  public void supportContentToString(Function<SourceItemT, String> toString) {
+    myContentToString = toString;
+  }
+
+  @Override
+  public void supportContentListToString(Function<List<SourceItemT>, String> listToString) {
+    myContentListToString = listToString;
+  }
+
+  @Override
+  public <ContentT> void supportContentKind(ContentKind<ContentT> kind, Function<ContentT, SourceItemT> fromContent) {
+    if (myContentKinds.containsKey(kind)) {
+      throw new IllegalArgumentException(kind + " already supported");
+    }
+    myContentKinds.put(kind, fromContent);
+  }
+
+  @Override
+  public <ContentT> void supportListContentKind(ContentKind<ContentT> kind, Function<ContentT, List<SourceItemT>> fromContent) {
+    if (!isMultiItemPasteSupported()) {
+      throw new IllegalArgumentException("Multi-item paste not supported");
+    }
+    if (myListContentKinds.containsKey(kind)) {
+      throw new IllegalArgumentException(kind + " already supported");
+    }
+    myListContentKinds.put(kind, fromContent);
   }
 
   protected Cell getTarget() {
@@ -342,7 +380,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
               return copiedItems.size() <= 1;
             }
 
-            return Objects.equal(kind, ContentKinds.listOf(myItemKind));
+            return Objects.equal(kind, listOf(myItemKind));
           }
 
           @Override
@@ -356,6 +394,17 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
               result.add(myCloner.apply(item));
             }
             return (T) result;
+          }
+
+          @Override
+          public String toString() {
+            if (myContentListToString != null) {
+              return myContentListToString.apply(copiedItems);
+            }
+            if (copiedItems.size() > 0 && myContentToString != null) {
+              return myContentToString.apply(copiedItems.get(0));
+            }
+            return super.toString();
           }
         };
       }
@@ -385,17 +434,46 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
       }
 
       private boolean canPaste(ClipboardContent content) {
-        if (myItemKind == null) return false;
-        if (content.isSupported(myItemKind)) return true;
-        return isMultiItemPasteSupported() && content.isSupported(ContentKinds.listOf(myItemKind));
+        for (ContentKind kind : myContentKinds.keySet()) {
+          if (content.isSupported(kind) || (isMultiItemPasteSupported() && content.isSupported(listOf(kind)))) {
+            return true;
+          }
+        }
+        if (isMultiItemPasteSupported()) {
+          for (ContentKind kind : myListContentKinds.keySet()) {
+            if (content.isSupported(kind)) {
+              return true;
+            }
+          }
+        }
+        return false;
       }
 
       private void paste(ClipboardContent content) {
-        if (isMultiItemPasteSupported() && content.isSupported(ContentKinds.listOf(myItemKind))) {
-          insertItems(content.get(ContentKinds.listOf(myItemKind))).run();
-        } else {
-          insertItem(content.get(myItemKind)).run();
+        for (ListMap<ContentKind, Function<?, SourceItemT>>.Entry entry : myContentKinds.entrySet()) {
+          ContentKind kind = entry.key();
+          Function<Object, SourceItemT> fromContent = (Function<Object, SourceItemT>) entry.value();
+          if (content.isSupported(entry.key())) {
+            Object contentValue = content.get(kind);
+            insertItem(fromContent.apply(contentValue)).run();
+            return;
+          } else if (isMultiItemPasteSupported() && content.isSupported(listOf(kind))) {
+            Object contentList = content.get(listOf(kind));
+            insertItems((List<SourceItemT>) fromContent.apply(contentList)).run();
+            return;
+          }
         }
+        if (isMultiItemPasteSupported()) {
+          for (ListMap<ContentKind, Function<?, List<SourceItemT>>>.Entry entry : myListContentKinds.entrySet()) {
+            ContentKind kind = entry.key();
+            if (content.isSupported(kind)) {
+              Function<Object, List<SourceItemT>> fromContent = (Function<Object, List<SourceItemT>>) entry.value();
+              insertItems(fromContent.apply(content.get(kind))).run();
+              return;
+            }
+          }
+        }
+        throw new IllegalStateException("canPaste() and paste() are inconsistent. Content: " + content);
       }
 
       @Override

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -28,6 +28,10 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void setCompletion(RoleCompletion<? super ContextT, SourceT> completion);
   void setDeleteHandler(DeleteHandler handler);
   void setClipboardParameters(ContentKind<SourceT> kind, Function<SourceT, SourceT> cloner);
+  void supportContentToString(Function<SourceT, String> toString);
+  void supportContentListToString(Function<List<SourceT>, String> listToString);
+  <ContentT> void supportContentKind(ContentKind<ContentT> kind, Function<ContentT, SourceT> fromContent);
+  <ContentT> void supportListContentKind(ContentKind<ContentT> kind, Function<ContentT, List<SourceT>> fromContent);
   void setOnLastItemDeleted(Runnable action);
   void setPlaceholderText(String text);
   void setItemFactory(Supplier<SourceT> itemFactory);

--- a/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
+++ b/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
@@ -52,7 +52,6 @@ import java.awt.datatransfer.*;
 import java.awt.event.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
-import java.awt.geom.Arc2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
 import java.io.ByteArrayInputStream;
@@ -246,7 +245,7 @@ public class ViewContainerComponent extends JComponent implements Scrollable {
               if (cb.isDataFlavorAvailable(DataFlavor.stringFlavor)) {
                 try {
                   String text = (String) cb.getData(DataFlavor.stringFlavor);
-                  myContainer.paste(new PasteEvent(new TextClipboardContent(text)));
+                  myContainer.paste(new PasteEvent(TextContentHelper.createClipboardContent(text)));
                   e.consume();
                   return;
                 } catch (UnsupportedFlavorException | IOException ex) {
@@ -265,8 +264,8 @@ public class ViewContainerComponent extends JComponent implements Scrollable {
               ClipboardContent content = event.getResult();
               if (content != null) {
                 String text;
-                if (content.isSupported(ContentKinds.TEXT)) {
-                  text = content.get(ContentKinds.TEXT);
+                if (content.isSupported(ContentKinds.ANY_TEXT)) {
+                  text = content.get(ContentKinds.ANY_TEXT);
                 } else {
                   text = content.toString();
                 }

--- a/view/src/main/java/jetbrains/jetpad/projectional/view/toGwt/ViewContainerToElementMapper.java
+++ b/view/src/main/java/jetbrains/jetpad/projectional/view/toGwt/ViewContainerToElementMapper.java
@@ -244,7 +244,7 @@ public class ViewContainerToElementMapper extends Mapper<ViewContainer, Element>
                       if (Strings.isNullOrEmpty(text)) {
                         getSource().keyPressed(e.copy());
                       } else {
-                        getSource().paste(new PasteEvent(new TextClipboardContent(text)));
+                        getSource().paste(new PasteEvent(TextContentHelper.createClipboardContent(text)));
                       }
                     }
                   });


### PR DESCRIPTION
NB: there is dependent pull request https://github.com/JetBrains/datapad/pull/11 which must be merged immediately after this. If you like both, please make sure I'm online and ready, then accept both.

Changes since https://github.com/JetBrains/jetpad-projectional/pull/185
* All naming and messaging recommendations accepted
* Introduced new content kind: `MULTILINE_TEXT`. There is also `ANY_TEXT` content kind for controllers convenience (see usages).
* In `BaseProjectionalSynchronizer`: from-content and to-content concepts are separated because in fact they don't depend on each other. Editor can support pasting from several content kinds and not support generating text, why not. Also, coupling text-generation with some clipboard content kind seems unnecessary. Consequently, content-kind-mappers are gone: to support different content kind client must provide only from-content function.