### PR TITLE
BaseProjectionalSynchronizer: added nullchecks on paste

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -152,7 +152,23 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   protected abstract Runnable insertItems(List<SourceItemT> items);
 
   protected Runnable insertItem(SourceItemT item) {
-    return insertItems(Arrays.asList(item));
+    return insertItems(Collections.singletonList(item));
+  }
+
+  private Runnable insertNonNullItemsList(List<SourceItemT> items) {
+    if (items != null) {
+      return insertItems(items);
+    } else {
+      return Runnables.EMPTY;
+    }
+  }
+
+  private Runnable insertNonNullItem(SourceItemT item) {
+    if (item != null) {
+      return insertItem(item);
+    } else {
+      return Runnables.EMPTY;
+    }
   }
 
   private Registration registerChild(SourceItemT child, Cell childCell) {
@@ -455,11 +471,11 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
           Function<Object, SourceItemT> fromContent = (Function<Object, SourceItemT>) entry.value();
           if (content.isSupported(entry.key())) {
             Object contentValue = content.get(kind);
-            insertItem(fromContent.apply(contentValue)).run();
+            insertNonNullItem(fromContent.apply(contentValue)).run();
             return;
           } else if (isMultiItemPasteSupported() && content.isSupported(listOf(kind))) {
             Object contentList = content.get(listOf(kind));
-            insertItems((List<SourceItemT>) fromContent.apply(contentList)).run();
+            insertNonNullItemsList((List<SourceItemT>) fromContent.apply(contentList)).run();
             return;
           }
         }
@@ -468,7 +484,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
             ContentKind kind = entry.key();
             if (content.isSupported(kind)) {
               Function<Object, List<SourceItemT>> fromContent = (Function<Object, List<SourceItemT>>) entry.value();
-              insertItems(fromContent.apply(content.get(kind))).run();
+              insertNonNullItemsList(fromContent.apply(content.get(kind))).run();
               return;
             }
           }

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -77,7 +77,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
         case "NonEmptyChild":
           return new NonEmptyChild();
         default:
-          throw new IllegalArgumentException(s);
+          return null;
       }
     }
   };
@@ -85,12 +85,17 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   private final Function<Iterable<String>, List<Child>> multilineParser = new Function<Iterable<String>, List<Child>>() {
     @Override
     public List<Child> apply(Iterable<String> items) {
-      return Lists.newArrayList(Iterables.transform(items, new Function<String, Child>() {
+      List<Child> children = Lists.newArrayList(Iterables.transform(items, new Function<String, Child>() {
         @Override
         public Child apply(String s) {
           return lineParser.apply(s);
         }
       }));
+      if (children.contains(null)) {
+        return null;
+      } else {
+        return children;
+      }
     }
   };
 
@@ -944,6 +949,22 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertEquals(2, container.children.size());
     assertTrue(container.children.get(0) instanceof EmptyChild);
     assertTrue(container.children.get(1) instanceof NonEmptyChild);
+  }
+
+  @Test
+  public void pasteIncorrectItem() {
+    rootMapper.mySynchronizer.supportListContentKind(ContentKinds.MULTILINE_TEXT, multilineParser);
+
+    paste("BadItem\n");
+    assertTrue(container.children.isEmpty());
+  }
+
+  @Test
+  public void pasteIncorrectItems() {
+    rootMapper.mySynchronizer.supportListContentKind(ContentKinds.MULTILINE_TEXT, multilineParser);
+
+    paste("BadItem\nEmptyChild\n");
+    assertTrue(container.children.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Real parsers may return `null` on incorrect input which was not handled properly in projectional's editor paste. There may be a question if we should remove nulls from list of items, but checking/filtering every inserted list brings additional overhead, so I decided to check only a list itself supposing parser returns either null list or list of non-nulls.