### PR TITLE
DP-819 Fixed right-to-left tokens selection

### DIFF
--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -303,6 +303,15 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void multipleNoSpaceToLeftSelectedProperly() {
+    setTokens(Tokens.RP, Tokens.RP, Tokens.RP, new IntValueToken(1));
+    select(3, false);
+
+    selectLeft(3);
+    assertSelection(0, 4);
+  }
+
+  @Test
   public void noExtraPositionInParens() {
     setTokens(Tokens.LP, new IntValueToken(2), Tokens.RP);
     select(1, false);

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/SelectionSupport.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/SelectionSupport.java
@@ -262,7 +262,7 @@ public class SelectionSupport<ItemT> {
             consumed = true;
           } else {
             if (!mySelectedItems.contains(currentItem) && Positions.isHomePosition(currentCell) && Positions.isEndPosition(currentCell)) {
-              mySelectedItems.add(currentItem);
+              mySelectedItems.add(0, currentItem);
               consumed = true;
             }
 


### PR DESCRIPTION
When you have multiple no-space-to-left tokens, more than one may be selected upon shift + left arrow, and in this case middle was is inserted to the incorrect place. Fixed.