### PR TITLE
BaseProjectionalSynchronizer: added nullchecks on paste

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -152,7 +152,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   protected abstract Runnable insertItems(List<SourceItemT> items);
 
   protected Runnable insertItem(SourceItemT item) {
-    return insertItems(Arrays.asList(item));
+    return insertItems(Collections.singletonList(item));
   }
 
   private Registration registerChild(SourceItemT child, Cell childCell) {
@@ -454,12 +454,16 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
           ContentKind kind = entry.key();
           Function<Object, SourceItemT> fromContent = (Function<Object, SourceItemT>) entry.value();
           if (content.isSupported(entry.key())) {
-            Object contentValue = content.get(kind);
-            insertItem(fromContent.apply(contentValue)).run();
+            SourceItemT item = fromContent.apply(content.get(kind));
+            if (item != null) {
+              insertItem(item);
+            }
             return;
           } else if (isMultiItemPasteSupported() && content.isSupported(listOf(kind))) {
-            Object contentList = content.get(listOf(kind));
-            insertItems((List<SourceItemT>) fromContent.apply(contentList)).run();
+            List<SourceItemT> itemsList = (List<SourceItemT>) fromContent.apply(content.get(listOf(kind)));
+            if (itemsList != null) {
+              insertItems(itemsList);
+            }
             return;
           }
         }
@@ -468,7 +472,10 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
             ContentKind kind = entry.key();
             if (content.isSupported(kind)) {
               Function<Object, List<SourceItemT>> fromContent = (Function<Object, List<SourceItemT>>) entry.value();
-              insertItems(fromContent.apply(content.get(kind))).run();
+              List<SourceItemT> items = fromContent.apply(content.get(kind));
+              if (items != null) {
+                insertItems(items);
+              }
               return;
             }
           }

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -77,7 +77,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
         case "NonEmptyChild":
           return new NonEmptyChild();
         default:
-          throw new IllegalArgumentException(s);
+          return null;
       }
     }
   };
@@ -85,12 +85,17 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   private final Function<Iterable<String>, List<Child>> multilineParser = new Function<Iterable<String>, List<Child>>() {
     @Override
     public List<Child> apply(Iterable<String> items) {
-      return Lists.newArrayList(Iterables.transform(items, new Function<String, Child>() {
+      List<Child> children = Lists.newArrayList(Iterables.transform(items, new Function<String, Child>() {
         @Override
         public Child apply(String s) {
           return lineParser.apply(s);
         }
       }));
+      if (children.contains(null)) {
+        return null;
+      } else {
+        return children;
+      }
     }
   };
 
@@ -944,6 +949,22 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertEquals(2, container.children.size());
     assertTrue(container.children.get(0) instanceof EmptyChild);
     assertTrue(container.children.get(1) instanceof NonEmptyChild);
+  }
+
+  @Test
+  public void pasteIncorrectItem() {
+    rootMapper.mySynchronizer.supportListContentKind(ContentKinds.MULTILINE_TEXT, multilineParser);
+
+    paste("BadItem\n");
+    assertTrue(container.children.isEmpty());
+  }
+
+  @Test
+  public void pasteIncorrectItems() {
+    rootMapper.mySynchronizer.supportListContentKind(ContentKinds.MULTILINE_TEXT, multilineParser);
+
+    paste("BadItem\nEmptyChild\n");
+    assertTrue(container.children.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Changes since https://github.com/JetBrains/jetpad-projectional/pull/196:
* Removed `insertNonNull...` methods, inlined nullchecks