### PR TITLE
Dropped ANY_TEXT content kind; replaced usages with util-methods calls

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
@@ -216,8 +216,8 @@ public class CellContainer {
 
   private void setContent(CopyCutEvent e) {
     myContent = e.getResult();
-    if (myContent.isSupported(ContentKinds.ANY_TEXT)) {
-      myLastSeenText = myContent.get(ContentKinds.ANY_TEXT);
+    if (TextContentHelper.isText(myContent)) {
+      myLastSeenText = TextContentHelper.getText(myContent);
     } else {
       myLastSeenText = myContent.toString();
     }

--- a/cell/src/main/java/jetbrains/jetpad/cell/toView/CellContainerToViewMapper.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/toView/CellContainerToViewMapper.java
@@ -316,8 +316,8 @@ public class CellContainerToViewMapper extends Mapper<CellContainer, View> {
         @Override
         public void handle(View view, PasteEvent e) {
           ClipboardContent content = e.getContent();
-          if (content.isSupported(ContentKinds.ANY_TEXT)) {
-            cellContainer.paste(content.get(ContentKinds.ANY_TEXT));
+          if (TextContentHelper.isText(content)) {
+            cellContainer.paste(TextContentHelper.getText(content));
             e.consume();
           }
         }

--- a/event/src/main/java/jetbrains/jetpad/event/ContentKinds.java
+++ b/event/src/main/java/jetbrains/jetpad/event/ContentKinds.java
@@ -20,7 +20,6 @@ import java.util.List;
 public class ContentKinds {
   public static final ContentKind<String> SINGLE_LINE_TEXT = create("singleLineText");
   public static final ContentKind<Iterable<String>> MULTILINE_TEXT = create("multilineText");
-  public static final ContentKind<String> ANY_TEXT = create("anyText");
 
   public static <T> ContentKind<T> create(final String name) {
     return new ContentKind<T>() {

--- a/event/src/main/java/jetbrains/jetpad/event/MultilineTextClipboardContent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/MultilineTextClipboardContent.java
@@ -26,13 +26,12 @@ class MultilineTextClipboardContent implements ClipboardContent {
 
   @Override
   public boolean isSupported(ContentKind<?> kind) {
-    return kind == MULTILINE_TEXT || kind == ANY_TEXT;
+    return kind == MULTILINE_TEXT;
   }
 
   @Override
   public <T> T get(ContentKind<T> kind) {
     if (kind == MULTILINE_TEXT) return (T) myLines;
-    if (kind == ANY_TEXT) return (T) TextContentHelper.joinLines(myLines);
 
     throw new IllegalArgumentException();
   }

--- a/event/src/main/java/jetbrains/jetpad/event/SingleLineTextClipboardContent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/SingleLineTextClipboardContent.java
@@ -15,8 +15,6 @@
  */
 package jetbrains.jetpad.event;
 
-import static jetbrains.jetpad.event.ContentKinds.ANY_TEXT;
-
 class SingleLineTextClipboardContent implements ClipboardContent {
   private String myText;
 
@@ -26,12 +24,12 @@ class SingleLineTextClipboardContent implements ClipboardContent {
 
   @Override
   public boolean isSupported(ContentKind<?> kind) {
-    return kind == ContentKinds.SINGLE_LINE_TEXT || kind == ANY_TEXT;
+    return kind == ContentKinds.SINGLE_LINE_TEXT;
   }
 
   @Override
   public <T> T get(ContentKind<T> kind) {
-    if (kind == ContentKinds.SINGLE_LINE_TEXT || kind == ANY_TEXT) return (T) myText;
+    if (kind == ContentKinds.SINGLE_LINE_TEXT) return (T) myText;
 
     throw new IllegalArgumentException();
   }

--- a/event/src/main/java/jetbrains/jetpad/event/TextContentHelper.java
+++ b/event/src/main/java/jetbrains/jetpad/event/TextContentHelper.java
@@ -18,6 +18,9 @@ package jetbrains.jetpad.event;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import static jetbrains.jetpad.event.ContentKinds.MULTILINE_TEXT;
+import static jetbrains.jetpad.event.ContentKinds.SINGLE_LINE_TEXT;
+
 public class TextContentHelper {
   private static final char CARRIAGE_RETURN = '\r';
   private static final char NEWLINE = '\n';
@@ -27,6 +30,20 @@ public class TextContentHelper {
       return new MultilineTextClipboardContent(splitByNewline(string));
     }
     return new SingleLineTextClipboardContent(string);
+  }
+
+  public static boolean isText(ClipboardContent content) {
+    return content.isSupported(SINGLE_LINE_TEXT) || content.isSupported(MULTILINE_TEXT);
+  }
+
+  public static String getText(ClipboardContent content) {
+    if (content.isSupported(SINGLE_LINE_TEXT)) {
+      return content.get(SINGLE_LINE_TEXT);
+    }
+    if (content.isSupported(MULTILINE_TEXT)) {
+      return joinLines(content.get(MULTILINE_TEXT));
+    }
+    throw new IllegalArgumentException(String.valueOf(content));
   }
 
   public static Iterable<String> splitByNewline(final String multiline) {

--- a/event/src/main/java/jetbrains/jetpad/event/dom/ClipboardSupport.java
+++ b/event/src/main/java/jetbrains/jetpad/event/dom/ClipboardSupport.java
@@ -22,7 +22,7 @@ import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextArea;
 import jetbrains.jetpad.base.Handler;
 import jetbrains.jetpad.event.ClipboardContent;
-import jetbrains.jetpad.event.ContentKinds;
+import jetbrains.jetpad.event.TextContentHelper;
 
 import static com.google.gwt.query.client.GQuery.$;
 
@@ -48,8 +48,8 @@ public class ClipboardSupport {
 
   public void copyContent(ClipboardContent content) {
     final TextArea copyArea = createClipboardTextArea();
-    if (content.isSupported(ContentKinds.ANY_TEXT)) {
-      copyArea.setText(content.get(ContentKinds.ANY_TEXT));
+    if (TextContentHelper.isText(content)) {
+      copyArea.setText(TextContentHelper.getText(content));
     } else {
       copyArea.setText(content.toString());
     }

--- a/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
+++ b/view/src/main/java/jetbrains/jetpad/projectional/view/toAwt/ViewContainerComponent.java
@@ -264,8 +264,8 @@ public class ViewContainerComponent extends JComponent implements Scrollable {
               ClipboardContent content = event.getResult();
               if (content != null) {
                 String text;
-                if (content.isSupported(ContentKinds.ANY_TEXT)) {
-                  text = content.get(ContentKinds.ANY_TEXT);
+                if (TextContentHelper.isText(content)) {
+                  text = TextContentHelper.getText(content);
                 } else {
                   text = content.toString();
                 }


### PR DESCRIPTION
As discussed in https://github.com/JetBrains/jetpad-projectional/pull/190, `ANY_TEXT` is not ok, so replaced with util methods pair: `isText()` and `getText()`.