### PR TITLE
DP-989 pretty printing support for SimpleHybridEditor

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
@@ -1,0 +1,163 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.hybrid.parser.Parser;
+import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinter;
+import jetbrains.jetpad.hybrid.parser.prettyprint.PrettyPrinterContext;
+import jetbrains.jetpad.model.collections.CollectionItemEvent;
+import jetbrains.jetpad.model.collections.CollectionListener;
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.event.EventHandler;
+import jetbrains.jetpad.model.event.ListenerCaller;
+import jetbrains.jetpad.model.event.Listeners;
+import jetbrains.jetpad.model.property.PropertyChangeEvent;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Note that this class sets a never-disposing listener on
+ * the {@code tokens} collection so their lifetime is always aligned.
+ */
+public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
+
+  private final Parser<? extends ModelT> myParser;
+  private final PrettyPrinter<? super ModelT> myPrinter;
+  private final ObservableList<Token> mySourceTokens;
+  private final ParsingContextFactory myParsingContextFactory;
+  private final ObservableList<Token> myPrettyTokens = new MyList();
+
+  private Listeners<EventHandler<? super PropertyChangeEvent<ModelT>>> myHandlers;
+  private ModelT myValue;
+  private boolean myInUpdate;
+
+  public ParsingHybridProperty(
+      Parser<? extends ModelT> parser,
+      PrettyPrinter<? super ModelT> printer,
+      ObservableList<Token> tokens, ParsingContextFactory parsingContextFactory) {
+    myParser = parser;
+    myPrinter = printer;
+    mySourceTokens = tokens;
+    myParsingContextFactory = parsingContextFactory;
+    myValue = parse();
+    update();
+    mySourceTokens.addListener(new CollectionListener<Token>() {
+      @Override
+      public void onItemAdded(CollectionItemEvent<? extends Token> event) {
+        update();
+      }
+
+      @Override
+      public void onItemSet(CollectionItemEvent<? extends Token> event) {
+        update();
+      }
+
+      @Override
+      public void onItemRemoved(CollectionItemEvent<? extends Token> event) {
+        update();
+      }
+    });
+  }
+
+  @Override
+  public final ModelT get() {
+    return myValue;
+  }
+
+  private ModelT parse() {
+    return myParser.parse(myParsingContextFactory.getParsingContext(mySourceTokens));
+  }
+
+  @Override
+  public Registration addHandler(final EventHandler<? super PropertyChangeEvent<ModelT>> handler) {
+    if (myHandlers == null) {
+      myHandlers = new Listeners<>();
+    }
+    return myHandlers.add(handler);
+  }
+
+  @Override
+  public ObservableList<Token> getTokens() {
+    return myPrettyTokens;
+  }
+
+  private void update() {
+    ModelT newValue = parse();
+    if (!Objects.equals(myValue, newValue))
+      updateValue(newValue);
+
+    myInUpdate = true;
+    try {
+      if (myValue != null) {
+        PrettyPrinterContext<? super ModelT> printCtx = new PrettyPrinterContext<>(myPrinter);
+        printCtx.print(myValue);
+        syncTokens(printCtx.tokens());
+      } else {
+        syncTokens(mySourceTokens);
+      }
+    } finally {
+      myInUpdate = false;
+    }
+  }
+
+  private void updateValue(ModelT newValue) {
+    final PropertyChangeEvent<ModelT> event = new PropertyChangeEvent<>(myValue, newValue);
+    myValue = newValue;
+
+    if (myHandlers != null) {
+      myHandlers.fire(new ListenerCaller<EventHandler<? super PropertyChangeEvent<ModelT>>>() {
+        @Override
+        public void call(EventHandler<? super PropertyChangeEvent<ModelT>> item) {
+          item.onEvent(event);
+        }
+      });
+    }
+  }
+
+  private void syncTokens(List<Token> newTokens) {
+    int i;
+    for (i = 0; i < newTokens.size(); i++) {
+      Token p = newTokens.get(i);
+      if (i < myPrettyTokens.size()) {
+        if (!Objects.equals(p, myPrettyTokens.get(i))) {
+          myPrettyTokens.set(i, p);
+        }
+      } else {
+        myPrettyTokens.add(p);
+      }
+    }
+
+    myPrettyTokens.subList(newTokens.size(), myPrettyTokens.size()).clear();
+  }
+
+  @Override
+  public String getPropExpr() {
+    return "ParsingHybridProperty["+mySourceTokens+"]";
+  }
+
+  private class MyList extends ObservableArrayList<Token> {
+    @Override
+    protected void afterItemAdded(int index, Token item, boolean success) {
+      if (!myInUpdate && success) {
+        mySourceTokens.add(index, item);
+      }
+    }
+
+    @Override
+    protected void afterItemSet(int index, Token oldItem, Token newItem, boolean success) {
+      if (!myInUpdate && success) {
+        mySourceTokens.set(index, newItem);
+      }
+    }
+
+    @Override
+    protected void afterItemRemoved(int index, Token item, boolean success) {
+      if (!myInUpdate && success) {
+        mySourceTokens.remove(index);
+      }
+    }
+  }
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/SimpleHybridProperty.java
@@ -24,6 +24,10 @@ import jetbrains.jetpad.model.collections.CollectionListener;
 import jetbrains.jetpad.model.collections.list.ObservableList;
 import jetbrains.jetpad.model.property.BaseDerivedProperty;
 
+/**
+ * @deprecated Doesn't support pretty printing. Use {@link ParsingHybridProperty} instead.
+ */
+@Deprecated
 public class SimpleHybridProperty<ModelT> extends BaseDerivedProperty<ModelT> implements HybridProperty<ModelT> {
 
   private final Parser<ModelT> myParser;

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -49,8 +49,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static jetbrains.jetpad.hybrid.SelectionPosition.FIRST;
-import static jetbrains.jetpad.hybrid.SelectionPosition.LAST;
+import static jetbrains.jetpad.hybrid.SelectionPosition.*;
 import static jetbrains.jetpad.hybrid.TokensUtil.*;
 import static org.junit.Assert.*;
 
@@ -1118,6 +1117,27 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     del();
 
     assertTokens(integer(1), Tokens.PLUS, integer(2), Tokens.PLUS, integer(3));
+  }
+
+  @Test
+  public void tokenUpdateAfterReparse() {
+    setTokens(new IdentifierToken("x"), Tokens.LP);
+
+    select(1, false);
+    type(")");
+
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
+  }
+
+  @Test
+  public void tokenUpdateAfterReparseAndSplit() {
+    setTokens(new IdentifierToken("id*"), new IdentifierToken("x"), Tokens.LP, Tokens.RP);
+
+    select(0, false);
+    left();
+    type(" ");
+
+    assertTokens(Tokens.ID, Tokens.MUL, new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
   }
 
   protected ValueToken createComplexToken() {

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/HybridEditorEditingTest.java
@@ -78,27 +78,6 @@ public class HybridEditorEditingTest extends BaseHybridEditorEditingTest<ExprCon
   }
 
   @Test
-  public void tokenUpdateAfterReparse() {
-    setTokens(new IdentifierToken("x"), Tokens.LP);
-
-    select(1, false);
-    type(")");
-
-    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
-  }
-
-  @Test
-  public void tokenUpdateAfterReparseAndSplit() {
-    setTokens(new IdentifierToken("id*"), new IdentifierToken("x"), Tokens.LP, Tokens.RP);
-
-    select(0, false);
-    left();
-    type(" ");
-
-    assertTokens(Tokens.ID, Tokens.MUL, new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
-  }
-
-  @Test
   public void tokenFocusAfterReparseAndSplitGivesDifferentTokens() {
     setTokens(new IdentifierToken("func("), Tokens.RP);
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/ParsingHybridPropertyTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/ParsingHybridPropertyTest.java
@@ -1,0 +1,175 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.hybrid.parser.*;
+import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
+import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.hybrid.testapp.model.CallExpr;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.MulExpr;
+import jetbrains.jetpad.hybrid.testapp.model.PlusExpr;
+import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.collections.list.ObservableList;
+import jetbrains.jetpad.model.event.EventHandler;
+import jetbrains.jetpad.model.property.PropertyChangeEvent;
+import jetbrains.jetpad.test.BaseTestCase;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ParsingHybridPropertyTest extends BaseTestCase {
+
+  private ObservableList<Token> mySourceTokens;
+  private HybridProperty<Expr> myProp;
+  private TestParser parser;
+
+  @Before
+  public void init() {
+    mySourceTokens = new ObservableArrayList<>();
+    final HybridEditorSpec<Expr> hybridEditorSpec = new ExprHybridEditorSpec();
+    parser = new TestParser(hybridEditorSpec);
+    myProp = new ParsingHybridProperty<>(
+      parser, hybridEditorSpec.getPrettyPrinter(), mySourceTokens, HybridEditorSpecUtil.getParsingContextFactory(hybridEditorSpec));
+  }
+
+  @Test
+  public void empty() {
+    assertNull(myProp.get());
+    assertTrue(myProp.getTokens().isEmpty());
+  }
+
+  @Test
+  public void tokenError() {
+    mySourceTokens.add(new ErrorToken("something wrong"));
+    assertEquals(mySourceTokens, myProp.getTokens());
+    assertNull(myProp.get());
+
+    mySourceTokens.clear();
+    myProp.getTokens().add(new ErrorToken("something other wrong"));
+    assertEquals(mySourceTokens, myProp.getTokens());
+    assertNull(myProp.get());
+  }
+
+  @Test
+  public void parserError() {
+    mySourceTokens.add(Tokens.PLUS);
+    assertNull(myProp.get());
+  }
+
+  @Test
+  public void invalidateSource() {
+    mySourceTokens.add(new IdentifierToken("a"));
+    mySourceTokens.add(Tokens.PLUS);
+    mySourceTokens.add(new IdentifierToken("b"));
+    assertTrue(myProp.get() instanceof PlusExpr);
+    assertEquals(mySourceTokens, myProp.getTokens());
+
+    mySourceTokens.remove(2);
+    assertNull(myProp.get());
+    assertEquals(mySourceTokens, myProp.getTokens());
+  }
+
+  @Test
+  public void validateSource() {
+    mySourceTokens.add(new IdentifierToken("a"));
+    mySourceTokens.add(Tokens.PLUS);
+    assertNull(myProp.get());
+    assertEquals(mySourceTokens, myProp.getTokens());
+
+    mySourceTokens.add(new IdentifierToken("b"));
+    assertTrue(myProp.get() instanceof PlusExpr);
+    assertEquals(mySourceTokens, myProp.getTokens());
+  }
+
+  @Test
+  public void invalidateTokens() {
+    myProp.getTokens().add(new IdentifierToken("a"));
+    myProp.getTokens().add(Tokens.PLUS);
+    myProp.getTokens().add(new IdentifierToken("b"));
+    assertTrue(myProp.get() instanceof PlusExpr);
+    assertEquals(mySourceTokens, myProp.getTokens());
+
+    myProp.getTokens().remove(2);
+    assertNull(myProp.get());
+    assertEquals(mySourceTokens, myProp.getTokens());
+  }
+
+  @Test
+  public void validateTokens() {
+    myProp.getTokens().add(new IdentifierToken("a"));
+    myProp.getTokens().add(Tokens.PLUS);
+    assertNull(myProp.get());
+    assertEquals(mySourceTokens, myProp.getTokens());
+
+    myProp.getTokens().add(new IdentifierToken("b"));
+    assertTrue(myProp.get() instanceof PlusExpr);
+    assertEquals(mySourceTokens, myProp.getTokens());
+  }
+
+  @Test
+  public void parserInvocations() {
+    Registration r = myProp.addHandler(new EventHandler<PropertyChangeEvent<Expr>>() {
+      @Override
+      public void onEvent(PropertyChangeEvent<Expr> event) { }
+    });
+
+    mySourceTokens.add(new IdentifierToken("a"));
+    mySourceTokens.add(Tokens.PLUS);
+    mySourceTokens.add(new IdentifierToken("b"));
+    assertEquals(5 /* Initial refresh + on add listener + 3 changes */,
+      parser.invocations);
+
+    mySourceTokens.set(2, Tokens.MUL);
+    assertEquals(6, parser.invocations);
+
+    r.remove();
+  }
+
+  @Test
+  public void reprint() {
+    mySourceTokens.add(Tokens.ID);
+    mySourceTokens.add(Tokens.MUL);
+    mySourceTokens.add(new IdentifierToken("x"));
+    mySourceTokens.add(Tokens.LP);
+    mySourceTokens.add(Tokens.RP);
+
+    assertTrue(myProp.get() instanceof MulExpr);
+    assertSame(myProp.getTokens().get(3), Tokens.LP_CALL);
+  }
+
+  @Test
+  public void withListener() {
+    Registration r = myProp.addHandler(new EventHandler<PropertyChangeEvent<Expr>>() {
+      @Override
+      public void onEvent(PropertyChangeEvent<Expr> event) { }
+    });
+
+    mySourceTokens.add(new IdentifierToken("x"));
+    myProp.getTokens().add(Tokens.LP);
+
+    assertNull(myProp.get());
+    assertEquals(mySourceTokens, myProp.getTokens());
+
+    myProp.getTokens().add(Tokens.RP);
+    assertTrue(myProp.get() instanceof CallExpr);
+    assertSame(myProp.getTokens().get(1), Tokens.LP_CALL);
+
+    r.remove();
+  }
+
+  private static class TestParser implements Parser<Expr> {
+    private final HybridEditorSpec<Expr> myHybridEditorSpec;
+    private int invocations = 0;
+
+    public TestParser(HybridEditorSpec<Expr> hybridEditorSpec) {
+      myHybridEditorSpec = hybridEditorSpec;
+    }
+
+    @Override
+    public Expr parse(ParsingContext ctx) {
+      invocations++;
+      return myHybridEditorSpec.getParser().parse(ctx);
+    }
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
@@ -1,13 +1,16 @@
 package jetbrains.jetpad.hybrid.testapp.model;
 
 import jetbrains.jetpad.hybrid.HybridProperty;
-import jetbrains.jetpad.hybrid.SimpleHybridProperty;
+import jetbrains.jetpad.hybrid.ParsingHybridProperty;
 import jetbrains.jetpad.hybrid.parser.SimpleParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
 
 public class SimpleExprContainer extends ExprNode {
-  public final HybridProperty<Expr> expr = new SimpleHybridProperty<>(
-    new ExprHybridEditorSpec().getParser(), new ObservableArrayList<Token>(), new SimpleParsingContextFactory());
+  private final ExprHybridEditorSpec editorSpec = new ExprHybridEditorSpec();
+
+  public final HybridProperty<Expr> expr = new ParsingHybridProperty<>(
+    editorSpec.getParser(), editorSpec.getPrettyPrinter(),
+    new ObservableArrayList<Token>(), new SimpleParsingContextFactory());
 }


### PR DESCRIPTION
The tokenFocusAfterReparseAndSplitGivesDifferentTokens test fails when I try to apply it to a simple hybrid editor, still investigating the cause.