### PR TITLE
Projectional sync: allowed copying only text

### DIFF
--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -968,6 +968,22 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
+  public void onlyTextualCopy() {
+    rootMapper.mySynchronizer.setClipboardParameters(null, null);
+    rootMapper.mySynchronizer.supportContentListToString(listToString);
+    container.children.add(new EmptyChild());
+    selectChild(0);
+
+    assertNull(cut());
+
+    ClipboardContent copied = copy();
+    assertEquals(getMultiline(new EmptyChild()), TextContentHelper.getText(copied));
+
+    paste(copied.toString());
+    assertEquals(1, container.children.size());
+  }
+
+  @Test
   public void canCopyFocusedItem() {
     container.children.add(new ComplexChild());
     selectChild(0);


### PR DESCRIPTION
You may setup projectional synchronizer to yield only textual clipboard without full cut/copy/paste support. This works similar to copying some text from disabled UI element: you can select and copy, but can't cut and paste.