### PR TITLE
DP-1019 Hybrid: copy tokens after copy and before paste

### DIFF
--- a/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/EditingTestCase.java
@@ -107,6 +107,12 @@ public abstract class EditingTestCase extends BaseTestCase {
     myEditableCellContainer.left();
   }
 
+  protected final void left(int steps) {
+    for (int i = 0; i < steps; i++) {
+      left();
+    }
+  }
+
   protected final void right() {
     myEditableCellContainer.right();
   }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -319,7 +319,10 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
 
       private ClipboardContent copy() {
         final Range<Integer> selection = selection();
-        final List<Token> tokens = new ArrayList<>(tokens().subList(selection.lowerEndpoint(), selection.upperEndpoint()));
+        final List<Token> copiedTokens = new ArrayList<>(selection.upperEndpoint() - selection.lowerEndpoint());
+        for (Token token : tokens().subList(selection.lowerEndpoint(), selection.upperEndpoint())) {
+          copiedTokens.add(token.copy());
+        }
         return new ClipboardContent() {
           @Override
           public boolean isSupported(ContentKind<?> kind) {
@@ -329,7 +332,11 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
           @Override
           public <T> T get(ContentKind<T> kind) {
             if (kind == TOKENS_CONTENT) {
-              return (T) Collections.unmodifiableList(tokens);
+              List<Token> result = new ArrayList<>(copiedTokens.size());
+              for (Token token : copiedTokens) {
+                result.add(token.copy());
+              }
+              return (T) Collections.unmodifiableList(result);
             }
             return null;
           }
@@ -337,7 +344,7 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
           @Override
           public String toString() {
             try {
-              return TokenUtil.getText(tokens);
+              return TokenUtil.getText(copiedTokens);
             } catch (UnsupportedOperationException e) {
               return super.toString();
             }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -1017,6 +1017,44 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void editStringAfterCopyBeforePaste() {
+    type("'x");
+    right();
+    selectLeft(1);
+
+    ClipboardContent content = copy();
+    String contentToString = content.toString();
+    right();
+    type("1");
+    end(); end();
+
+    paste(contentToString);
+
+    assertTokens(singleQtd("1x"), singleQtd("x"));
+  }
+
+  @Test
+  public void editStringAfterPaste() {
+    type("'x");
+    right();
+    selectLeft(1);
+
+    ClipboardContent content = copy();
+    String contentToString = content.toString();
+    end();
+
+    paste(contentToString);
+    paste(contentToString);
+
+    left();
+    type("2");
+    left(5);
+    type("1");
+
+    assertTokens(singleQtd("x"), singleQtd("x1"), singleQtd("x2"));
+  }
+
+  @Test
   public void hideTokensInMenuForHybridWrapperRole() {
     HybridWrapperRoleCompletion<Object, Expr, Expr> hybridWrapperRole = new HybridWrapperRoleCompletion<>(getSpec(), null, null, true);
     CompletionSupplier roleCompletion = hybridWrapperRole.createRoleCompletion(mapper, null, null);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
@@ -41,9 +41,6 @@ class TokensUtil {
     return new ValueToken(new ValueExpr(), new ValueExprCloner());
   }
 
-  static Token async() {
-    return new ValueToken(new AsyncValueExpr(), new ValueExprCloner());
-  }
   static Token error(String text) {
     return new ErrorToken(text);
   }
@@ -77,7 +74,7 @@ class TokensUtil {
       assertTrue(actualValue instanceof PosValueExpr);
     } else if (expectedValue instanceof StringExpr) {
       assertTrue(actualValue instanceof StringExpr);
-      assertEquals(actualValue.toString(), expectedValue.toString());
+      assertEquals(expectedValue.toString(), actualValue.toString());
     } else {
       assertEquals(expectedValue, actualValue);
     }


### PR DESCRIPTION
Just like Projectional Editor does, Hybrid now copies tokens after copy() and before paste(). First copy needed to protect clipboard content from edits in source tokens; second copy needed to separate multiple pastes of same content.

In `TokenUtils`: minor changes: removed unused, corrected expected/actual order.