### PR TITLE
CompletionItem: changed matching priority from boolean to integer

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionItems.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionItems.java
@@ -20,6 +20,7 @@ import jetbrains.jetpad.completion.CompletionItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 public class CompletionItems {
@@ -68,17 +69,28 @@ public class CompletionItems {
   }
 
   private List<CompletionItem> reduce(List<CompletionItem> items) {
-    List<CompletionItem> lowPriority = new ArrayList<>();
-    List<CompletionItem> result = new ArrayList<>();
-    for (CompletionItem item : items) {
-      if (item.isLowMatchPriority()) {
-        lowPriority.add(item);
-      } else {
-        result.add(item);
+    if (items.size() <= 1) {
+      return items;
+    } else {
+      Iterator<CompletionItem> i = items.iterator();
+      CompletionItem firstItem = i.next();
+
+      int winningPriority = firstItem.getMatchPriority();
+      List<CompletionItem> winningItems = new ArrayList<>();
+      winningItems.add(firstItem);
+
+      while (i.hasNext()) {
+        CompletionItem item = i.next();
+        if (item.getMatchPriority() == winningPriority) {
+          winningItems.add(item);
+        } else if (item.getMatchPriority() > winningPriority) {
+          winningPriority = item.getMatchPriority();
+          winningItems.clear();
+          winningItems.add(item);
+        }
       }
+      return winningItems;
     }
-    if (result.isEmpty()) return lowPriority;
-    return result;
   }
 
   public boolean hasSingleMatch(String text, boolean eager) {

--- a/cell/src/test/java/jetbrains/jetpad/cell/text/ValidTextCompletionTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/text/ValidTextCompletionTest.java
@@ -76,8 +76,8 @@ public class ValidTextCompletionTest extends CompletionTestCase {
                 }
 
                 @Override
-                public boolean isLowMatchPriority() {
-                  return true;
+                public int getMatchPriority() {
+                  return super.getMatchPriority() - 1;
                 }
 
                 @Override
@@ -113,8 +113,8 @@ public class ValidTextCompletionTest extends CompletionTestCase {
                 }
 
                 @Override
-                public boolean isLowMatchPriority() {
-                  return true;
+                public int getMatchPriority() {
+                  return super.getMatchPriority() - 1;
                 }
 
                 @Override

--- a/completion/src/main/java/jetbrains/jetpad/completion/BaseCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/BaseCompletionItem.java
@@ -17,8 +17,8 @@ package jetbrains.jetpad.completion;
 
 public abstract class BaseCompletionItem implements CompletionItem {
   @Override
-  public boolean isLowMatchPriority() {
-    return false;
+  public int getMatchPriority() {
+    return 0;
   }
 
   @Override

--- a/completion/src/main/java/jetbrains/jetpad/completion/CompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/CompletionItem.java
@@ -35,11 +35,12 @@ public interface CompletionItem {
   boolean isMatch(String text);
 
   /**
-   * Low match priority means that if we have two strictly matching items one with low priority and another without it, then the higher
-   * priority item beats the lower priority item. We need this in order to support variable references and keyword variables. If
+   * Match priority matters when we have > 1 strictly matching items with different priorities - a subset with
+   * the highest priority wins. One of use cases is supporting variable references and keyword variables. If
    * there's a keyword expression, it beats variable reference.
+   * The greater is returned number, the higher is priority.
    */
-  boolean isLowMatchPriority();
+  int getMatchPriority();
 
   /**
    * Use this priority to move items higher in completion menu. Default priority should be 0. The higher

--- a/completion/src/main/java/jetbrains/jetpad/completion/WrapperCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/WrapperCompletionItem.java
@@ -43,8 +43,8 @@ public class WrapperCompletionItem implements CompletionItem {
   }
 
   @Override
-  public boolean isLowMatchPriority() {
-    return myItem.isLowMatchPriority();
+  public int getMatchPriority() {
+    return myItem.getMatchPriority();
   }
 
   @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
@@ -85,8 +85,8 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
             }
 
             @Override
-            public boolean isLowMatchPriority() {
-              return true;
+            public int getMatchPriority() {
+              return super.getMatchPriority() - 1;
             }
 
             @Override
@@ -115,7 +115,7 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
           });
         } else {
           if (!(cp.isMenu() && myHideTokensInMenu)) {
-            for (CompletionItem ci : mySpec.getTokenCompletion(new Function<Token, Runnable>() {
+            for (final CompletionItem ci : mySpec.getTokenCompletion(new Function<Token, Runnable>() {
               @Override
               public Runnable apply(Token input) {
                 return completer.complete(input);
@@ -123,8 +123,8 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
             }).get(cp)) {
               result.add(new WrapperCompletionItem(ci) {
                 @Override
-                public boolean isLowMatchPriority() {
-                  return true;
+                public int getMatchPriority() {
+                  return super.getMatchPriority() - 1;
                 }
               });
             }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletionItems.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCompletionItems.java
@@ -109,8 +109,8 @@ public class TokenCompletionItems {
       }
 
       @Override
-      public boolean isLowMatchPriority() {
-        return true;
+      public int getMatchPriority() {
+        return super.getMatchPriority() - 1;
       }
     };
   }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionTokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionTokenizerTest.java
@@ -97,6 +97,12 @@ public class CompletionTokenizerTest {
   }
 
   @Test
+  public void tripleQuotedString() {
+    List<Token> tokens = tokenizer.tokenize("'''x'''");
+    assertTokensEqual(of(tripleQtd("x")), tokens);
+  }
+
+  @Test
   public void longCorrectExpression() {
     List<Token> tokens = tokenizer.tokenize("\t( 10) * 5! + id.value ++ + '\"text 1\"' + \"text 2\"");
     assertTokensEqual(of(LP, integer(10), RP, MUL, integer(5), FACTORIAL, PLUS, ID, DOT, value(), INCREMENT, PLUS,

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/TokensUtil.java
@@ -29,6 +29,10 @@ class TokensUtil {
     return new ValueToken(new StringExpr("\"", body), new ValueExprCloner(), new ValueExprTextGen());
   }
 
+  static Token tripleQtd(String body) {
+    return new ValueToken(new StringExpr("'''", body), new ValueExprCloner(), new ValueExprTextGen());
+  }
+
   static Token complex() {
     return new ValueToken(new ComplexValueExpr(), new ValueExprCloner());
   }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -330,8 +330,18 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
             return tokenHandler.apply(new ValueToken(new PosValueExpr(), new ValueExprCloner()));
           }
         });
-        for (final String quote : new String[] { "\"", "'" }) {
+
+        String[] quotes = new String[] { "\"", "'", "'''" };
+        int[] priorities = new int[] { 0, 0, -1 };
+        for (int i = 0; i < quotes.length; i++) {
+          final String quote = quotes[i];
+          final int priority = priorities[i];
+
           result.add(new ByBoundsCompletionItem(quote, quote) {
+            @Override
+            public int getMatchPriority() {
+              return priority;
+            }
             @Override
             public Runnable complete(String text) {
               StringExpr stringExpr = new StringExpr(quote);
@@ -344,6 +354,7 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
             }
           });
         }
+
         final String commentPrefix = "#";
         result.add(new ByBoundsCompletionItem(commentPrefix) {
           @Override


### PR DESCRIPTION
The problem with `boolean` priority was in `HybridWrapperRoleCompletion`: it erased priority info in `WrapperCompletionItem` setting it to constant. This complicated, for example, implementing multiple String completion items of different priorities (flat priorities cause ambiguous completion). New implementation does not erase but decreases the priority instead.

NB: there is dependent request which must be merged immediately: https://github.com/JetBrains/datapad/pull/12