### PR TITLE
DP-1026 No completion in the dot position

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/completion/Completion.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/completion/Completion.java
@@ -32,6 +32,8 @@ public class Completion {
   public static final CellTraitPropertySpec<CompletionSupplier> RIGHT_TRANSFORM = new CellTraitPropertySpec<>("rightTransform", CompletionSupplier.EMPTY);
   public static final CellTraitPropertySpec<CompletionController> COMPLETION_CONTROLLER = new CellTraitPropertySpec<>("completionController");
 
+  public static final CellTraitPropertySpec<CompletionConfig> COMPLETION_CONFIG = new CellTraitPropertySpec<>("completionConfig", (CompletionConfig) new DefaultCompletionConfig());
+
   public static Async<Iterable<CompletionItem>> allCompletion(Cell cell, CompletionParameters params) {
     final CompletionSupplier supplier = cell.get(COMPLETION);
     final Iterable<CompletionItem> syncCompletion = supplier.get(params);

--- a/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionConfig.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionConfig.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.cell.completion;
+
+public interface CompletionConfig {
+
+  boolean canDoRightTransform(CompletionItems completionItems, String prefixText);
+
+}

--- a/cell/src/main/java/jetbrains/jetpad/cell/completion/DefaultCompletionConfig.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/completion/DefaultCompletionConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.cell.completion;
+
+import jetbrains.jetpad.completion.CompletionItem;
+
+import java.util.List;
+
+final class DefaultCompletionConfig implements CompletionConfig {
+
+  DefaultCompletionConfig() {
+  }
+
+  @Override
+  public boolean canDoRightTransform(CompletionItems completionItems, String prefixText) {
+    List<CompletionItem> matches = completionItems.matches(prefixText);
+    List<CompletionItem> strictlyPrefixed = completionItems.strictlyPrefixedBy(prefixText);
+    return matches.size() == 1 && strictlyPrefixed.isEmpty();
+  }
+
+}

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -100,35 +100,31 @@ public class TextEditingTrait extends TextNavigationTrait {
     String currentText = TextEditing.text(editor);
     CompletionItems completion = new CompletionItems(cell.get(Completion.COMPLETION).get(CompletionParameters.EMPTY));
     String prefixText = TextEditing.getPrefixText(editor);
-    if (TextEditing.isEnd(editor)) {
-      List<CompletionItem> matches = completion.matches(prefixText);
-      List<CompletionItem> strictlyPrefixed = completion.strictlyPrefixedBy(prefixText);
-      if (matches.size() == 1 && strictlyPrefixed.isEmpty()) {
-        BaseCompletionParameters cp = new BaseCompletionParameters() {
-          @Override
-          public boolean isEndRightTransform() {
-            return true;
-          }
-
-          @Override
-          public boolean isMenu() {
-            return true;
-          }
-        };
-        CompletionSupplier supplier = cell.get(Completion.RIGHT_TRANSFORM);
-        if ((!supplier.isEmpty(cp) || !supplier.isAsyncEmpty(cp)) && cell.get(TextEditing.RT_ON_END)) {
-          if (cell.get(Cell.RIGHT_POPUP) == null) {
-            TextCell popup = CompletionSupport.showSideTransformPopup(cell, cell.rightPopup(), cell.get(Completion.RIGHT_TRANSFORM), true);
-            popup.get(Completion.COMPLETION_CONTROLLER).activate(new Runnable() {
-              @Override
-              public void run() {
-                cell.focus();
-              }
-            });
-          }
-          event.consume();
-          return;
+    if (TextEditing.isEnd(editor) && cell.get(Completion.COMPLETION_CONFIG).canDoRightTransform(completion, prefixText)) {
+      BaseCompletionParameters cp = new BaseCompletionParameters() {
+        @Override
+        public boolean isEndRightTransform() {
+          return true;
         }
+
+        @Override
+        public boolean isMenu() {
+          return true;
+        }
+      };
+      CompletionSupplier supplier = cell.get(Completion.RIGHT_TRANSFORM);
+      if ((!supplier.isEmpty(cp) || !supplier.isAsyncEmpty(cp)) && cell.get(TextEditing.RT_ON_END)) {
+        if (cell.get(Cell.RIGHT_POPUP) == null) {
+          TextCell popup = CompletionSupport.showSideTransformPopup(cell, cell.rightPopup(), cell.get(Completion.RIGHT_TRANSFORM), true);
+          popup.get(Completion.COMPLETION_CONTROLLER).activate(new Runnable() {
+            @Override
+            public void run() {
+              cell.focus();
+            }
+          });
+        }
+        event.consume();
+        return;
       }
     }
 

--- a/cell/src/test/java/jetbrains/jetpad/cell/text/ValidTextCompletionTest.java
+++ b/cell/src/test/java/jetbrains/jetpad/cell/text/ValidTextCompletionTest.java
@@ -23,6 +23,7 @@ import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.TextCell;
 import jetbrains.jetpad.cell.completion.CellCompletionController;
 import jetbrains.jetpad.cell.completion.Completion;
+import jetbrains.jetpad.cell.completion.CompletionConfig;
 import jetbrains.jetpad.cell.completion.CompletionItems;
 import jetbrains.jetpad.cell.completion.CompletionTestCase;
 import jetbrains.jetpad.cell.trait.CellTrait;
@@ -159,7 +160,7 @@ public class ValidTextCompletionTest extends CompletionTestCase {
               }
 
               final List<CompletionItem> simpleItems = new ArrayList<>();
-              simpleItems.addAll(FluentIterable.from(createCompletion("a", "c", "ae", "zz", "d", "u", "q").get(cp)).toList());
+              simpleItems.addAll(FluentIterable.from(createCompletion("a", "c", "ae", "zz", "d", "u", "q", "p", "ppp").get(cp)).toList());
               simpleItems.add(new LowPriorityCompletionItem("d"));
               simpleItems.add(new LowPriorityCompletionItem("xx"));
               simpleItems.add(new LowPriorityCompletionItem("qq"));
@@ -196,6 +197,16 @@ public class ValidTextCompletionTest extends CompletionTestCase {
 
         if (spec == TextEditing.RT_ON_END) {
           return true;
+        }
+
+        if (spec == Completion.COMPLETION_CONFIG) {
+          return new CompletionConfig() {
+            @Override
+            public boolean canDoRightTransform(CompletionItems completionItems, String prefixText) {
+              List<CompletionItem> matches = completionItems.matches(prefixText);
+              return matches.size() == 1;
+            }
+          };
         }
 
         return super.get(cell, spec);
@@ -369,6 +380,16 @@ public class ValidTextCompletionTest extends CompletionTestCase {
   @Test
   public void rightTransformOnEnd() {
     type("xx");
+
+    complete();
+    enter();
+
+    assertTrue(rtCompleted);
+  }
+
+  @Test
+  public void rightTransformOnEnd_strictlyPrefixedNotEmpty() {
+    type("p");
 
     complete();
     enter();

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -20,6 +20,8 @@ import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.CellContainer;
 import jetbrains.jetpad.cell.TextCell;
 import jetbrains.jetpad.cell.completion.Completion;
+import jetbrains.jetpad.cell.completion.CompletionConfig;
+import jetbrains.jetpad.cell.completion.CompletionItems;
 import jetbrains.jetpad.cell.position.Positions;
 import jetbrains.jetpad.cell.text.TextEditing;
 import jetbrains.jetpad.cell.trait.CellTrait;
@@ -27,6 +29,7 @@ import jetbrains.jetpad.cell.trait.CellTraitEventSpec;
 import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
 import jetbrains.jetpad.cell.trait.CompositeCellTrait;
 import jetbrains.jetpad.cell.util.Cells;
+import jetbrains.jetpad.completion.CompletionItem;
 import jetbrains.jetpad.event.Event;
 import jetbrains.jetpad.event.Key;
 import jetbrains.jetpad.event.KeyEvent;
@@ -188,6 +191,16 @@ class TokenCellTraits {
     public Object get(Cell cell, CellTraitPropertySpec<?> spec) {
       if (spec == Completion.COMPLETION && !hybridSync(cell).hasSelection()) {
         return tokenCompletion(cell).tokenCompletion(cell);
+      }
+
+      if (spec == Completion.COMPLETION_CONFIG) {
+        return new CompletionConfig() {
+          @Override
+          public boolean canDoRightTransform(CompletionItems completionItems, String prefixText) {
+            List<CompletionItem> matches = completionItems.matches(prefixText);
+            return matches.size() == 1;
+          }
+        };
       }
 
       return super.get(cell, spec);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -304,7 +304,10 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
       public List<CompletionItem> get(CompletionParameters cp) {
         List<CompletionItem> result = new ArrayList<>();
         TokenCompletionItems items = new TokenCompletionItems(tokenHandler);
-        result.addAll(items.forTokens(Tokens.ID, Tokens.INCREMENT, Tokens.FACTORIAL, Tokens.PLUS, Tokens.MUL, Tokens.LP, Tokens.RP, Tokens.DOT));
+        result.addAll(items.forTokens(
+            Tokens.ID, Tokens.INCREMENT, Tokens.FACTORIAL, Tokens.PLUS, Tokens.MUL, Tokens.LP, Tokens.RP, Tokens.DOT,
+            Tokens.ELLIPSIS
+        ));
         result.add(items.forNumber());
         result.add(new SimpleCompletionItem("func") {
           @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/Tokens.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/Tokens.java
@@ -29,6 +29,8 @@ public class Tokens {
   public static final Token RP = new SimpleToken(")", true, false);
   public static final Token DOT = new SimpleToken(".", true, true, true);
 
+  static final Token ELLIPSIS = new SimpleToken("...");
+
   static boolean isLp(Token token) {
     return token == LP || token == LP_CALL;
   }


### PR DESCRIPTION
- We don't need strictlyPrefixed.isEmpty() check in the hybrid editor but we need it in the projecitonal editor. 
- Added test: jetbrains.jetpad.cell.text.ValidTextCompletionTest#rightTransformOnEnd_strictlyPrefixedNotEmpty
- Didn't add a test in hybrid tests. Adding ELLIPSIS ("...") broke two tests. Implementing CompletionConfig in TokenCellTraits (jetbrains/jetpad/hybrid/TokenCellTraits.java:196) fixed those tests.