### PR TITLE
ByBoundsCompletionItem: if suffix specified, it is required

### DIFF
--- a/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
+++ b/completion/src/main/java/jetbrains/jetpad/completion/ByBoundsCompletionItem.java
@@ -37,22 +37,35 @@ public abstract class ByBoundsCompletionItem extends BaseCompletionItem {
 
   @Override
   public boolean isStrictMatchPrefix(String text) {
-    return text.length() < myPrefix.length() && myPrefix.startsWith(text);
+    return text.length() < myPrefix.length() && myPrefix.startsWith(text)
+        || isSuffixSpecified() && isPrefixedButNotSuffixed(text);
   }
 
   @Override
   public boolean isMatch(String text) {
-    return hasPrefixAndDoesNotExceedSuffix(text);
+    if (isSuffixSpecified()) {
+      return isPrefixedAndSuffixed(text);
+    } else {
+      return text.startsWith(myPrefix);
+    }
   }
 
-  private boolean hasPrefixAndDoesNotExceedSuffix(String text) {
+  private boolean isSuffixSpecified() {
+    return mySuffix.length() > 0;
+  }
+
+  private boolean isPrefixedButNotSuffixed(String text) {
+    return isPrefixedAndHasSuffixAt(text, -1);
+  }
+
+  private boolean isPrefixedAndSuffixed(String text) {
+    return isPrefixedAndHasSuffixAt(text, text.length() - mySuffix.length());
+  }
+
+  private boolean isPrefixedAndHasSuffixAt(String text, int expectedSuffixPos) {
     if (text.startsWith(myPrefix)) {
-      int suffixLength = mySuffix.length();
-      if (suffixLength > 0) {
-        int suffixPos = text.indexOf(mySuffix, myPrefix.length());
-        return (suffixPos == -1) || (suffixPos == text.length() - suffixLength);
-      }
-      return true;
+      int suffixPos = text.indexOf(mySuffix, myPrefix.length());
+      return expectedSuffixPos == suffixPos;
     }
     return false;
   }

--- a/completion/src/test/java/jetbrains/jetpad/completion/BaseCompletionItemTestCase.java
+++ b/completion/src/test/java/jetbrains/jetpad/completion/BaseCompletionItemTestCase.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.completion;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public abstract class BaseCompletionItemTestCase {
+  private CompletionItem completionItem;
+
+  @Before
+  public void setup() {
+    completionItem = createCompletionItem();
+  }
+
+  abstract CompletionItem createCompletionItem();
+
+  @Test
+  public void strictPrefixes() {
+    for (String strictPrefix : getStrictPrefixes()) {
+      assertTrue(strictPrefix, completionItem.isStrictMatchPrefix(strictPrefix));
+      assertFalse(strictPrefix, completionItem.isMatch(strictPrefix));
+    }
+  }
+
+  @Test
+  public void matches() {
+    for (String match : getMatches()) {
+      assertFalse(match, completionItem.isStrictMatchPrefix(match));
+      assertTrue(match, completionItem.isMatch(match));
+    }
+  }
+
+  @Test
+  public void badItems() {
+    for (String bad : getBadItems()) {
+      assertFalse(bad, completionItem.isStrictMatchPrefix(bad));
+      assertFalse(bad, completionItem.isMatch(bad));
+    }
+  }
+
+  abstract String[] getStrictPrefixes();
+
+  abstract String[] getMatches();
+
+  abstract String[] getBadItems();
+}

--- a/completion/src/test/java/jetbrains/jetpad/completion/ByBoundsWithSuffixTest.java
+++ b/completion/src/test/java/jetbrains/jetpad/completion/ByBoundsWithSuffixTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.completion;
+
+import jetbrains.jetpad.base.Runnables;
+
+public class ByBoundsWithSuffixTest extends BaseCompletionItemTestCase {
+  @Override
+  CompletionItem createCompletionItem() {
+    return new ByBoundsCompletionItem("'", "'") {
+      @Override
+      public Runnable complete(String text) {
+        return Runnables.EMPTY;
+      }
+    };
+  }
+
+  @Override
+  String[] getStrictPrefixes() {
+    return new String[] { "", "'", "'x" };
+  }
+
+  @Override
+  String[] getMatches() {
+    return new String[] { "''", "'x'" };
+  }
+
+  @Override
+  String[] getBadItems() {
+    return new String[] { " '", " ''", "'''", "a'b'", "'a'b" };
+  }
+}

--- a/completion/src/test/java/jetbrains/jetpad/completion/ByBoundsWithoutSuffixTest.java
+++ b/completion/src/test/java/jetbrains/jetpad/completion/ByBoundsWithoutSuffixTest.java
@@ -16,21 +16,30 @@
 package jetbrains.jetpad.completion;
 
 import jetbrains.jetpad.base.Runnables;
-import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-
-public final class ByBoundsCompletionItemTest {
-
-  @Test
-  public void noSuffix() {
-    ByBoundsCompletionItem byBoundsCompletionItem = new ByBoundsCompletionItem("#") {
+public class ByBoundsWithoutSuffixTest extends BaseCompletionItemTestCase {
+  @Override
+  CompletionItem createCompletionItem() {
+    return new ByBoundsCompletionItem("#") {
       @Override
       public Runnable complete(String text) {
         return Runnables.EMPTY;
       }
     };
-    assertTrue(byBoundsCompletionItem.isMatch("# + 3"));
   }
 
+  @Override
+  String[] getStrictPrefixes() {
+    return new String[] { "" };
+  }
+
+  @Override
+  String[] getMatches() {
+    return new String[] { "#", "##", "# + 3"};
+  }
+
+  @Override
+  String[] getBadItems() {
+    return new String[] { " ", " #", "x", "x#" };
+  }
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -914,6 +914,28 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void completeToEmptyString() {
+    type("'");
+    assertTokens(singleQtd(""));
+  }
+
+  @Test
+  public void completeToNonemptyString() {
+    type("abc'");
+    home();
+    type("'");
+    assertTokens(singleQtd("abc"));
+  }
+
+  @Test
+  public void typeQuoteBeforeNumber() {
+    type("10");
+    home();
+    type("'");
+    assertTokens(singleQtd(""), integer(10));
+  }
+
+  @Test
   public void copyPasteToken() {
     setTokens(Tokens.ID, Tokens.PLUS);
     select(0, true);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionTokenizerTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/CompletionTokenizerTest.java
@@ -87,7 +87,7 @@ public class CompletionTokenizerTest {
   @Test
   public void incompleteStringLiteral() {
     List<Token> tokens = tokenizer.tokenize("\"text 1");
-    assertTokensEqual(of(doubleQtd("text 1")), tokens);
+    assertTokensEqual(of(error("\"text 1")), tokens);
   }
 
   @Test

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/mapper/ExprHybridEditorSpec.java
@@ -335,15 +335,35 @@ public class ExprHybridEditorSpec implements HybridEditorSpec<Expr> {
         });
 
         String[] quotes = new String[] { "\"", "'", "'''" };
-        int[] priorities = new int[] { 0, 0, -1 };
+        int[] simpleCompletionPriorities = new int[] { 0, 0, -1 };
+        final int byBoundsCompletionPriority = -2;
         for (int i = 0; i < quotes.length; i++) {
           final String quote = quotes[i];
-          final int priority = priorities[i];
+          final int simpleCompletionPriority = simpleCompletionPriorities[i];
+
+          if (!cp.isMenu()) {
+            result.add(new SimpleCompletionItem(quote) {
+              @Override
+              public int getMatchPriority() {
+                return simpleCompletionPriority;
+              }
+              @Override
+              public Runnable complete(String text) {
+                StringExpr stringExpr = new StringExpr(quote);
+                stringExpr.body.set(text.substring(quote.length()));
+                return tokenHandler.apply(new ValueToken(stringExpr, new ValueExprCloner(), new ValueExprTextGen()));
+              }
+              @Override
+              public int getSortPriority() {
+                return -1;
+              }
+            });
+          }
 
           result.add(new ByBoundsCompletionItem(quote, quote) {
             @Override
             public int getMatchPriority() {
-              return priority;
+              return byBoundsCompletionPriority;
             }
             @Override
             public Runnable complete(String text) {


### PR DESCRIPTION
**NB:** there's dependent pull request https://github.com/JetBrains/datapad/pull/13. Please merge both or neither.

The previous `ByBoundsCompletionItem` implementation could complete even if a string does not end with specified suffix. For quoted string case
* `"` -> `""`
* `"a` -> `"a"`
* `"b"` -> `"b"`

This was needed to satisfy both editor case (`"` completes to a string) and copypaste case (`"abc"`completes to `"abc"`). However, there is one issue about this implementation: when you have any valid token (id, number), typing a quote from its home position turns this token into a string. For example, you have integer `10`, and type from home position `"`.
* Expected: `"" 10`
* Actual: `"10"`

Correct solution: having different completions for editor case (simple `"`-matching) and copypaste case (matching by prefix and suffix); latter must have lower priority which disables it for simple edit case. Earlier this was not possible because of priorities erasure in wrapping completions, but https://github.com/JetBrains/jetpad-projectional/pull/212 eliminated this limitation.