### PR TITLE
broken comments 

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.hybrid;
 
 import jetbrains.jetpad.base.Registration;
+import jetbrains.jetpad.hybrid.parser.CommentToken;
 import jetbrains.jetpad.hybrid.parser.Parser;
 import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
@@ -144,8 +145,9 @@ public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
         myPrettyTokens.add(p);
       }
     }
-
-    myPrettyTokens.subList(newTokens.size(), myPrettyTokens.size()).clear();
+    if (newTokens.size() < myPrettyTokens.size() && !(myPrettyTokens.get(newTokens.size()) instanceof CommentToken)) {
+      myPrettyTokens.subList(newTokens.size(), myPrettyTokens.size()).clear();
+    }
   }
 
   @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
@@ -2,7 +2,7 @@ package jetbrains.jetpad.hybrid.testapp.model;
 
 import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.ParsingHybridProperty;
-import jetbrains.jetpad.hybrid.parser.SimpleParsingContextFactory;
+import jetbrains.jetpad.hybrid.parser.CommentParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
@@ -12,5 +12,5 @@ public class SimpleExprContainer extends ExprNode {
 
   public final HybridProperty<Expr> expr = new ParsingHybridProperty<>(
     editorSpec.getParser(), editorSpec.getPrettyPrinter(),
-    new ObservableArrayList<Token>(), new SimpleParsingContextFactory());
+    new ObservableArrayList<Token>(), new CommentParsingContextFactory());
 }


### PR DESCRIPTION
The comments are broken by this commit: bee76d7 DP-989 pretty printing support for SimpleHybridEditor by @azlobinjb. 
The tests were passing because we had SimpleParsingContextFactory instead of CommentParsingContextFactory in this place.
The tests should be fixed either in this pull request (or somewhere else).