### PR TITLE
better way of creating parsing context factory

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridEditorSpecUtil.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridEditorSpecUtil.java
@@ -19,9 +19,9 @@ import jetbrains.jetpad.hybrid.parser.CommentParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.ParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.SimpleParsingContextFactory;
 
-final class HybridEditorSpecUtil {
+public final class HybridEditorSpecUtil {
 
-  static ParsingContextFactory getParsingContextFactory(SimpleHybridEditorSpec<?> simpleHybridEditorSpec) {
+  public static ParsingContextFactory getParsingContextFactory(SimpleHybridEditorSpec<?> simpleHybridEditorSpec) {
     ParsingContextFactory parsingContextFactory;
     CommentSpec commentSpec = simpleHybridEditorSpec.getCommentSpec();
     String commentPrefix = commentSpec.getCommentPrefix();

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
@@ -1,16 +1,31 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package jetbrains.jetpad.hybrid.testapp.model;
 
+import jetbrains.jetpad.hybrid.HybridEditorSpecUtil;
 import jetbrains.jetpad.hybrid.HybridProperty;
 import jetbrains.jetpad.hybrid.ParsingHybridProperty;
-import jetbrains.jetpad.hybrid.parser.CommentParsingContextFactory;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
 
 public class SimpleExprContainer extends ExprNode {
-  private final ExprHybridEditorSpec editorSpec = new ExprHybridEditorSpec();
+  private final ExprHybridEditorSpec myEditorSpec = new ExprHybridEditorSpec();
 
   public final HybridProperty<Expr> expr = new ParsingHybridProperty<>(
-    editorSpec.getParser(), editorSpec.getPrettyPrinter(),
-    new ObservableArrayList<Token>(), new CommentParsingContextFactory());
+      myEditorSpec.getParser(), myEditorSpec.getPrettyPrinter(),
+      new ObservableArrayList<Token>(), HybridEditorSpecUtil.getParsingContextFactory(myEditorSpec));
 }


### PR DESCRIPTION
In this case the parsing context factory should be a derivative of a hybridEditorSpec.