### PR TITLE
ProjSync: client can disable a placeholder so that empty model produces no output

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -34,6 +34,7 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   <ContentT> void supportListContentKind(ContentKind<ContentT> kind, Function<ContentT, List<SourceT>> fromContent);
   void setOnLastItemDeleted(Runnable action);
   void setPlaceholderText(String text);
+  void disablePlaceholder();
   void setItemFactory(Supplier<SourceT> itemFactory);
   void setSeparator(Character ch);
 

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -1074,6 +1074,28 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     assertEquals(2, container.children.size());
   }
 
+  @Test
+  public void placeholderDisabled() {
+    container.children.add(new EmptyChild());
+    rootMapper.mySynchronizer.setOnLastItemDeleted(Runnables.EMPTY);
+    rootMapper.mySynchronizer.disablePlaceholder();
+    container.children.clear();
+    assertTrue(rootMapper.getTarget().container.children().isEmpty());
+    assertNull(myCellContainer.focusedCell.get());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void placeholderDisabledIncorrectly() {
+    rootMapper.mySynchronizer.disablePlaceholder();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void onLastItemDeletedActionRestoredIncorrectly() {
+    rootMapper.mySynchronizer.setOnLastItemDeleted(Runnables.EMPTY);
+    rootMapper.mySynchronizer.disablePlaceholder();
+    rootMapper.mySynchronizer.setOnLastItemDeleted(null);
+  }
+
   private Child get(int index) {
     return container.children.get(index);
   }


### PR DESCRIPTION
Changes since https://github.com/JetBrains/jetpad-projectional/pull/227
* Removed runnable parameter from `disablePlaceholder()`
* Added checks which throw exceptions on incorrect combination
* Added tests expecting those exceptions