### PR TITLE
DP-1065: cell style when hovered and un-hovered

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/Cell.java
@@ -58,6 +58,7 @@ public abstract class Cell implements NavComposite<Cell>, HasVisibility, HasFocu
   public static final CellPropertySpec<Boolean> POPUP = new CellPropertySpec<>("popup", false);
   public static final CellPropertySpec<Boolean> HAS_POPUP_DECORATION = new CellPropertySpec<>("popupDecoration", false);
 
+  public static final CellPropertySpec<Boolean> HOVERED = new CellPropertySpec<>("hovered", false);
   public static final CellPropertySpec<Boolean> FOCUSED = new CellPropertySpec<>("focused", false);
   public static final CellPropertySpec<Boolean> VISIBLE = new CellPropertySpec<>("visible", true);
   public static final CellPropertySpec<Boolean> SELECTED = new CellPropertySpec<>("selected", false);
@@ -120,6 +121,10 @@ public abstract class Cell implements NavComposite<Cell>, HasVisibility, HasFocu
   public Cell lastChild() {
     if (myChildren == null) return null;
     return myChildren.get(myChildren.size() - 1);
+  }
+
+  public Property<Boolean> hovered() {
+    return getProp(HOVERED);
   }
 
   public Property<Boolean> visible() {

--- a/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/CellContainer.java
@@ -179,18 +179,16 @@ public class CellContainer {
 
   private void changeCellUnderMouse(MouseEvent e, Cell newCell) {
     if (newCell == myCellUnderMouse) return;
-
     if (myCellUnderMouse != null) {
+      myCellUnderMouse.set(Cell.HOVERED, false);
       dispatch(myCellUnderMouse, new MouseEvent(e.getLocation()), CellEventSpec.MOUSE_LEFT);
     }
-
+    myCellUnderMouse = newCell;
     if (newCell != null) {
+      newCell.set(Cell.HOVERED, true);
       dispatch(newCell, new MouseEvent(e.getLocation()), CellEventSpec.MOUSE_ENTERED);
     }
-
-    myCellUnderMouse = newCell;
   }
-
 
   public void copy(CopyCutEvent e) {
     dispatch(e, CellEventSpec.COPY);

--- a/cell/src/main/java/jetbrains/jetpad/cell/toDom/BaseCellMapper.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/toDom/BaseCellMapper.java
@@ -169,6 +169,7 @@ abstract class BaseCellMapper<SourceT extends Cell> extends Mapper<SourceT, Elem
   private void applyStyle(boolean selected, boolean focusHighlighted, Color background) {
     updateCssStyle(CSS.selected(), (focusHighlighted && !isLeaf()) || selected);
     updateCssStyle(CSS.paired(), getSource().get(Cell.PAIR_HIGHLIGHTED));
+    updateCssStyle(CSS.link(), getSource().get(Cell.LINK));
 
     String backgroundColor = null;
     if (isLeaf() && focusHighlighted) {
@@ -176,14 +177,11 @@ abstract class BaseCellMapper<SourceT extends Cell> extends Mapper<SourceT, Elem
     } else if (background != null) {
       backgroundColor = background.toCssColor();
     }
-    if (getSource().get(Cell.LINK)) {
-      updateCssStyle(CSS.link(), true);
-    } else {
-      updateCssStyle(CSS.link(), false);
-      String underline = getSource().get(Cell.RED_UNDERLINE) ? CSS.redUnderline()
-          : (getSource().get(Cell.YELLOW_UNDERLINE) ? CSS.yellowUnderline() : null);
-      applyBackground(backgroundColor, underline);
-    }
+
+    String underline = getSource().get(Cell.LINK) && getSource().get(Cell.HOVERED) ? CSS.blueUnderline()
+        : getSource().get(Cell.RED_UNDERLINE) ? CSS.redUnderline()
+        : getSource().get(Cell.YELLOW_UNDERLINE) ? CSS.yellowUnderline() : null;
+    applyBackground(backgroundColor, underline);
 
     Style style = getTarget().getStyle();
     Color borderColor = getSource().get(Cell.BORDER_COLOR);

--- a/cell/src/main/java/jetbrains/jetpad/cell/toDom/CellToDomCss.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/toDom/CellToDomCss.java
@@ -42,6 +42,7 @@ public interface CellToDomCss extends CssResource {
   String currentHighlightColor();
   String redUnderline();
   String yellowUnderline();
+  String blueUnderline();
   String link();
 
   String popup();

--- a/cell/src/main/java/jetbrains/jetpad/cell/toView/BaseCellMapper.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/toView/BaseCellMapper.java
@@ -151,7 +151,7 @@ class BaseCellMapper<SourceT extends Cell, TargetT extends View> extends Mapper<
     }
     getTarget().background().set(background);
 
-    if (getSource().get(Cell.LINK)) {
+    if (getSource().get(Cell.LINK) && getSource().get(Cell.HOVERED)) {
       getTarget().border().set(Color.BLUE);
     } else if (getSource().get(Cell.RED_UNDERLINE)) {
       getTarget().border().set(Color.RED);

--- a/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
+++ b/cell/src/main/resources/jetbrains/jetpad/cell/toDom/style.css
@@ -163,7 +163,6 @@
   transform: rotate(-135deg);
 }
 
-.link:hover {
+.link {
   cursor: pointer;
-  background: blueUnderline bottom repeat-x !important;
 }


### PR DESCRIPTION
This fixes http://jetpad.myjetbrains.com/youtrack/issue/DP-1065. And, this commit brings accurate background handling for 'link' cells. No more background clearance for focused cell which is also a link.