### PR TITLE
DP-1064 Accurate comment token handiling when editing

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/ParsingHybridProperty.java
@@ -66,18 +66,51 @@ public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
     update();
     mySourceTokens.addListener(new CollectionListener<Token>() {
       @Override
-      public void onItemAdded(CollectionItemEvent<? extends Token> event) {
-        update();
+      public void onItemAdded(final CollectionItemEvent<? extends Token> event) {
+        if (event.getNewItem() instanceof CommentToken) {
+          executeInUpdate(new Runnable() {
+            @Override
+            public void run() {
+              myPrettyTokens.add(event.getIndex(), event.getNewItem());
+            }
+          });
+        } else {
+          update();
+        }
       }
 
       @Override
-      public void onItemSet(CollectionItemEvent<? extends Token> event) {
-        update();
+      public void onItemSet(final CollectionItemEvent<? extends Token> event) {
+        if (event.getNewItem() instanceof CommentToken) {
+          executeInUpdate(new Runnable() {
+            @Override
+            public void run() {
+              myPrettyTokens.set(event.getIndex(), event.getNewItem());
+            }
+          });
+          if (!(event.getOldItem() instanceof CommentToken)) {
+            update();
+          }
+        } else if (event.getOldItem() instanceof CommentToken) {
+          myPrettyTokens.set(event.getIndex(), event.getNewItem());
+          update();
+        } else {
+          update();
+        }
       }
 
       @Override
-      public void onItemRemoved(CollectionItemEvent<? extends Token> event) {
-        update();
+      public void onItemRemoved(final CollectionItemEvent<? extends Token> event) {
+        if (event.getOldItem() instanceof CommentToken) {
+          executeInUpdate(new Runnable() {
+            @Override
+            public void run() {
+              myPrettyTokens.remove(event.getIndex());
+            }
+          });
+        } else {
+          update();
+        }
       }
     });
   }
@@ -105,31 +138,37 @@ public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
   }
 
   private void initUpdate() {
-    myInUpdate = true;
-    try {
-      syncTokens(mySourceTokens);
-    } finally {
-      myInUpdate = false;
-    }
+    executeInUpdate(new Runnable() {
+      @Override
+      public void run() {
+        updatePrettyTokens(mySourceTokens);
+      }
+    });
   }
 
   private void update() {
-    ModelT newValue = parse();
-    myInUpdate = true;
-    try {
-      if (newValue != null) {
-        PrettyPrinterContext<? super ModelT> printCtx = new PrettyPrinterContext<>(myPrinter);
-        printCtx.print(newValue);
-        syncTokens(printCtx.tokens());
-      } else {
-        syncTokens(mySourceTokens);
+    executeInUpdate(new Runnable() {
+      @Override
+      public void run() {
+        ModelT newValue = parse();
+        myInUpdate = true;
+        try {
+          if (newValue != null) {
+            PrettyPrinterContext<? super ModelT> printCtx = new PrettyPrinterContext<>(myPrinter);
+            printCtx.print(newValue);
+            updatePrettyTokens(printCtx.tokens());
+          } else {
+            myPrettyTokens.clear();
+            myPrettyTokens.addAll(mySourceTokens);
+          }
+        } finally {
+          myInUpdate = false;
+        }
+        if (!Objects.equals(myValue, newValue)) {
+          updateValue(newValue);
+        }
       }
-    } finally {
-      myInUpdate = false;
-    }
-    if (!Objects.equals(myValue, newValue)) {
-      updateValue(newValue);
-    }
+    });
   }
 
   private void updateValue(ModelT newValue) {
@@ -146,20 +185,22 @@ public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
     }
   }
 
-  private void syncTokens(List<Token> newTokens) {
+  private void updatePrettyTokens(List<Token> newTokens) {
     int i;
     for (i = 0; i < newTokens.size(); i++) {
       Token p = newTokens.get(i);
       if (i < myPrettyTokens.size()) {
-        if (!Objects.equals(p, myPrettyTokens.get(i))) {
+        if (myPrettyTokens.get(i) instanceof CommentToken) {
+          myPrettyTokens.add(i, p);
+        } else if (!Objects.equals(p, myPrettyTokens.get(i))) {
           myPrettyTokens.set(i, p);
         }
       } else {
         myPrettyTokens.add(p);
       }
     }
-    if (newTokens.size() < myPrettyTokens.size() && !(myPrettyTokens.get(newTokens.size()) instanceof CommentToken)) {
-      myPrettyTokens.subList(newTokens.size(), myPrettyTokens.size()).clear();
+    while (newTokens.size() < myPrettyTokens.size() && !(myPrettyTokens.get(newTokens.size()) instanceof CommentToken)) {
+      myPrettyTokens.remove(newTokens.size());
     }
   }
 
@@ -170,23 +211,52 @@ public class ParsingHybridProperty<ModelT> implements HybridProperty<ModelT> {
 
   private class MyList extends ObservableArrayList<Token> {
     @Override
-    protected void afterItemAdded(int index, Token item, boolean success) {
-      if (!myInUpdate && success) {
-        mySourceTokens.add(index, item);
+    protected void afterItemAdded(final int index, final Token item, boolean success) {
+      executeInUpdate(new Runnable() {
+        @Override
+        public void run() {
+          mySourceTokens.add(index, item);
+        }
+      });
+      if (!(item instanceof CommentToken)) {
+        update();
       }
     }
 
     @Override
-    protected void afterItemSet(int index, Token oldItem, Token newItem, boolean success) {
-      if (!myInUpdate && success) {
-        mySourceTokens.set(index, newItem);
+    protected void afterItemSet(final int index, Token oldItem, final Token newItem, boolean success) {
+      executeInUpdate(new Runnable() {
+        @Override
+        public void run() {
+          mySourceTokens.set(index, newItem);
+        }
+      });
+      if (!(oldItem instanceof CommentToken && newItem instanceof CommentToken)) {
+        update();
       }
     }
 
     @Override
-    protected void afterItemRemoved(int index, Token item, boolean success) {
-      if (!myInUpdate && success) {
-        mySourceTokens.remove(index);
+    protected void afterItemRemoved(final int index, Token item, boolean success) {
+      executeInUpdate(new Runnable() {
+        @Override
+        public void run() {
+          mySourceTokens.remove(index);
+        }
+      });
+      if (!(item instanceof CommentToken)) {
+        update();
+      }
+    }
+  }
+
+  private void executeInUpdate(Runnable body) {
+    if (!myInUpdate) {
+      myInUpdate = true;
+      try {
+        body.run();
+      } finally {
+        myInUpdate = false;
       }
     }
   }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridEditorExternalTokensChangeTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridEditorExternalTokensChangeTest.java
@@ -1,0 +1,176 @@
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.IdentifierToken;
+import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.hybrid.testapp.mapper.SimpleExprContainerMapper;
+import jetbrains.jetpad.hybrid.testapp.mapper.Tokens;
+import jetbrains.jetpad.hybrid.testapp.model.Expr;
+import jetbrains.jetpad.hybrid.testapp.model.SimpleExprContainer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static jetbrains.jetpad.hybrid.TokensUtil.comment;
+
+public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditorTest<SimpleExprContainer, SimpleExprContainerMapper> {
+  @Override
+  protected SimpleExprContainer createContainer() {
+    return new SimpleExprContainer();
+  }
+
+  @Override
+  protected SimpleExprContainerMapper createMapper() {
+    return new SimpleExprContainerMapper(container);
+  }
+
+  @Override
+  protected BaseHybridSynchronizer<Expr, ?> getSync(SimpleExprContainerMapper mapper) {
+    return mapper.hybridSync;
+  }
+
+  @Override
+  protected Expr getExpr() {
+    return container.expr.get();
+  }
+
+
+  @Before
+  public void setup() {
+    initEditor();
+  }
+
+  @Test
+  public void addMakeCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    container.sourceTokens.add(2, Tokens.RP);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void addMakeIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.add(2, Tokens.RP);
+    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void removeMakeCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+    container.sourceTokens.remove(3);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void removeMakeIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.remove(2);
+    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+  }
+
+  @Test
+  public void addCommentToCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP);
+    container.sourceTokens.add(comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void addCommentToIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP);
+    container.sourceTokens.add(comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+  }
+
+  @Test
+  public void removeCommentFromCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.remove(3);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
+  }
+
+  @Test
+  public void removeCommentFromIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    container.sourceTokens.remove(2);
+    assertTokens(new IdentifierToken("x"), Tokens.LP);
+  }
+
+  @Test
+  public void replaceCommentInCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.set(3, comment("retest"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("retest"));
+  }
+
+  @Test
+  public void replaceCommentInIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    container.sourceTokens.set(2, comment("retest"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("retest"));
+  }
+
+  @Test
+  public void replaceCommentWithAnotherCorrectToCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.set(3, Tokens.FACTORIAL);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, Tokens.FACTORIAL);
+  }
+
+  @Test
+  public void replaceCommentWithAnotherCorrectToIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
+    container.sourceTokens.set(3, Tokens.RP);
+    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP);
+  }
+
+  @Test
+  public void replaceCommentWithAnotherIncorrectToCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    container.sourceTokens.set(2, Tokens.RP);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP);
+  }
+
+  @Test
+  public void replaceCommentWithAnotherIncorrectToIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+    container.sourceTokens.set(4, Tokens.FACTORIAL);
+    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, Tokens.FACTORIAL);
+  }
+
+  @Test
+  public void replaceWithCommentCorrectToCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.FACTORIAL);
+    container.sourceTokens.set(3, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void replaceWithCommentCorrectToIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP);
+    container.sourceTokens.set(2, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+  }
+
+  @Test
+  public void replaceWithCommentIncorrectToCorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP);
+    container.sourceTokens.set(3, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, comment("test"));
+  }
+
+  @Test
+  public void replaceWithCommentIncorrectToIncorrect() {
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, Tokens.FACTORIAL);
+    container.sourceTokens.set(4, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+  }
+
+  private void assertTokens(Token... tokens) {
+    TokensUtil.assertTokensEqual(Arrays.asList(tokens), sync.tokens());
+  }
+
+  private void setTokens(Token... tokens) {
+    sync.setTokens(Arrays.asList(tokens));
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/testapp/model/SimpleExprContainer.java
@@ -21,11 +21,14 @@ import jetbrains.jetpad.hybrid.ParsingHybridProperty;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.hybrid.testapp.mapper.ExprHybridEditorSpec;
 import jetbrains.jetpad.model.collections.list.ObservableArrayList;
+import jetbrains.jetpad.model.collections.list.ObservableList;
 
 public class SimpleExprContainer extends ExprNode {
   private final ExprHybridEditorSpec myEditorSpec = new ExprHybridEditorSpec();
 
+  public final ObservableList<Token> sourceTokens = new ObservableArrayList<>();
+
   public final HybridProperty<Expr> expr = new ParsingHybridProperty<>(
       myEditorSpec.getParser(), myEditorSpec.getPrettyPrinter(),
-      new ObservableArrayList<Token>(), HybridEditorSpecUtil.getParsingContextFactory(myEditorSpec));
+      sourceTokens, HybridEditorSpecUtil.getParsingContextFactory(myEditorSpec));
 }


### PR DESCRIPTION
This fights several cases of exceptions when editing an expression with comment. Problems were mainly when tokens were changed externally (not by Hybrid Editor), that is, undo case. All of them are covered with the test provided.