### PR TITLE
Implemented postprocessor which runs after all actions on tokens finished

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/trait/CompositeCellTrait.java
@@ -119,7 +119,7 @@ public abstract class CompositeCellTrait extends CellTrait {
   @Override
   public void onKeyPressedLowPriority(Cell cell, KeyEvent event) {
     for (CellTrait t : getBaseTraits(cell)) {
-      t.onKeyReleasedLowPriority(cell, event);
+      t.onKeyPressedLowPriority(cell, event);
     }
   }
 

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -756,8 +756,13 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
   // NB: ValueTokens may have their own content editing handling -
   // in this case this post-processor won't run
   public void setTokensEditPostProcessor(TokensEditPostProcessor<SourceT> tokensEditPostProcessor) {
-    myTokensEditPostProcessor = tokensEditPostProcessor;
-    myTokenTextEditPostProcessorTrait = new TokenTextEditPostProcessorTrait<>(this, tokensEditPostProcessor);
+    if (tokensEditPostProcessor != null) {
+      myTokensEditPostProcessor = tokensEditPostProcessor;
+      myTokenTextEditPostProcessorTrait = new TokenTextEditPostProcessorTrait<>(this, tokensEditPostProcessor);
+    } else {
+      myTokensEditPostProcessor = new EmptyTokensEditPostProcessor<>();
+      myTokenTextEditPostProcessorTrait = CellTrait.EMPTY;
+    }
   }
 
   protected abstract Registration onAttach(Property<SourceT> syncValue);

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -33,12 +33,12 @@ class TextTokenCell extends TextCell {
   private boolean myFirst;
   private Token myToken;
   private Token myNextToken;
-  private final TokensEditPostProcessor<?> myPostProcessor;
+  private final CellTrait myPostProcessorTrait;
 
-  TextTokenCell(BaseHybridSynchronizer<?, ?> sync, Token token, TokensEditPostProcessor<?> postProcessor) {
+  TextTokenCell(BaseHybridSynchronizer<?, ?> sync, Token token, CellTrait postProcessorTrait) {
     mySync = sync;
     myToken = token;
-    myPostProcessor = postProcessor;
+    myPostProcessorTrait = postProcessorTrait;
 
     textColor().set(tokenTextColor());
     bold().set(token instanceof SimpleToken && ((SimpleToken) token).isBold());
@@ -74,23 +74,15 @@ class TextTokenCell extends TextCell {
   }
 
   private CellTrait createTrait() {
-    final CellTrait[] baseTraits = (myPostProcessor == null)
-        ? new CellTrait[] {
-            new TokenCellTraits.LeftLeafTokenCellTrait(),
-            new TokenCellTraits.RightLeafTokenCellTrait(),
-            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false)
-        }
-        : new CellTrait[] {
-            new TokenCellTraits.LeftLeafTokenCellTrait(),
-            new TokenCellTraits.RightLeafTokenCellTrait(),
-            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false),
-            new TokenTextEditPostProcessorTrait(mySync, myPostProcessor)
-        };
-
     return new TokenCellTraits.TokenCellTrait(false) {
       @Override
       protected CellTrait[] getBaseTraits(Cell cell) {
-        return baseTraits;
+        return new CellTrait[] {
+            new TokenCellTraits.LeftLeafTokenCellTrait(),
+            new TokenCellTraits.RightLeafTokenCellTrait(),
+            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false),
+            myPostProcessorTrait
+        };
       }
 
       @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -84,7 +84,7 @@ class TextTokenCell extends TextCell {
             new TokenCellTraits.LeftLeafTokenCellTrait(),
             new TokenCellTraits.RightLeafTokenCellTrait(),
             TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false),
-            new TokensEditPostProcessorTrait(mySync, myPostProcessor)
+            new TokenTextEditPostProcessorTrait(mySync, myPostProcessor)
         };
 
     return new TokenCellTraits.TokenCellTrait(false) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -33,10 +33,12 @@ class TextTokenCell extends TextCell {
   private boolean myFirst;
   private Token myToken;
   private Token myNextToken;
+  private final TokensEditPostProcessor<?> myPostProcessor;
 
-  TextTokenCell(BaseHybridSynchronizer<?, ?> sync, Token token) {
+  TextTokenCell(BaseHybridSynchronizer<?, ?> sync, Token token, TokensEditPostProcessor<?> postProcessor) {
     mySync = sync;
     myToken = token;
+    myPostProcessor = postProcessor;
 
     textColor().set(tokenTextColor());
     bold().set(token instanceof SimpleToken && ((SimpleToken) token).isBold());
@@ -72,14 +74,23 @@ class TextTokenCell extends TextCell {
   }
 
   private CellTrait createTrait() {
+    final CellTrait[] baseTraits = (myPostProcessor == null)
+        ? new CellTrait[] {
+            new TokenCellTraits.LeftLeafTokenCellTrait(),
+            new TokenCellTraits.RightLeafTokenCellTrait(),
+            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false)
+        }
+        : new CellTrait[] {
+            new TokenCellTraits.LeftLeafTokenCellTrait(),
+            new TokenCellTraits.RightLeafTokenCellTrait(),
+            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false),
+            new TokensEditPostProcessorTrait(mySync, myPostProcessor)
+        };
+
     return new TokenCellTraits.TokenCellTrait(false) {
       @Override
       protected CellTrait[] getBaseTraits(Cell cell) {
-        return new CellTrait[] {
-          new TokenCellTraits.LeftLeafTokenCellTrait(),
-          new TokenCellTraits.RightLeafTokenCellTrait(),
-          TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false)
-        };
+        return baseTraits;
       }
 
       @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
@@ -17,14 +17,13 @@ package jetbrains.jetpad.hybrid;
 
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.trait.CellTrait;
-import jetbrains.jetpad.event.Key;
-import jetbrains.jetpad.event.KeyEvent;
+import jetbrains.jetpad.event.*;
 
-class TokensEditPostProcessorTrait<SourceT> extends CellTrait {
-  private BaseHybridSynchronizer<SourceT, ?> mySync;
-  private TokensEditPostProcessor<SourceT> myPostProcessor;
+class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
+  private final BaseHybridSynchronizer<SourceT, ?> mySync;
+  private final TokensEditPostProcessor<SourceT> myPostProcessor;
 
-  TokensEditPostProcessorTrait(BaseHybridSynchronizer<SourceT, ?> sync, TokensEditPostProcessor<SourceT> postProcessor) {
+  TokenTextEditPostProcessorTrait(BaseHybridSynchronizer<SourceT, ?> sync, TokensEditPostProcessor<SourceT> postProcessor) {
     mySync = sync;
     myPostProcessor = postProcessor;
   }
@@ -37,6 +36,23 @@ class TokensEditPostProcessorTrait<SourceT> extends CellTrait {
   @Override
   public void onKeyPressed(Cell cell, KeyEvent event) {
     if (isRemove(event)) {
+      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+    }
+  }
+
+  @Override
+  public void onCut(Cell cell, CopyCutEvent event) {
+    if (event.getResult() != null
+        && event.getResult().isSupported(ContentKinds.SINGLE_LINE_TEXT)
+        && !TextContentHelper.getText(event.getResult()).isEmpty()) {
+      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+    }
+  }
+
+  @Override
+  public void onPaste(Cell cell, PasteEvent event) {
+    if (event.getContent().isSupported(ContentKinds.SINGLE_LINE_TEXT)
+        && !TextContentHelper.getText(event.getContent()).isEmpty()) {
       myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
     }
   }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
@@ -41,6 +41,13 @@ class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
   }
 
   @Override
+  public void onKeyPressedLowPriority(Cell cell, KeyEvent event) {
+    if (isRemove(event)) {
+      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+    }
+  }
+
+  @Override
   public void onCut(Cell cell, CopyCutEvent event) {
     if (event.getResult() != null
         && event.getResult().isSupported(ContentKinds.SINGLE_LINE_TEXT)

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessor.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.hybrid.parser.Token;
+
+import java.util.List;
+
+public interface TokensEditPostProcessor<SourceT> {
+  void afterTokensEdit(List<Token> tokens, SourceT value);
+}

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessorTrait.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessorTrait.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.hybrid;
+
+import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.cell.trait.CellTrait;
+import jetbrains.jetpad.event.Key;
+import jetbrains.jetpad.event.KeyEvent;
+
+class TokensEditPostProcessorTrait<SourceT> extends CellTrait {
+  private BaseHybridSynchronizer<SourceT, ?> mySync;
+  private TokensEditPostProcessor<SourceT> myPostProcessor;
+
+  TokensEditPostProcessorTrait(BaseHybridSynchronizer<SourceT, ?> sync, TokensEditPostProcessor<SourceT> postProcessor) {
+    mySync = sync;
+    myPostProcessor = postProcessor;
+  }
+
+  @Override
+  public void onKeyTyped(Cell cell, KeyEvent event) {
+    myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+  }
+
+  @Override
+  public void onKeyPressed(Cell cell, KeyEvent event) {
+    if (isRemove(event)) {
+      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+    }
+  }
+
+  private boolean isRemove(KeyEvent event) {
+    return event.getKey() == Key.BACKSPACE || event.getKey() == Key.DELETE;
+  }
+}

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -1349,6 +1349,16 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void postProcessorUninstall() {
+    Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(true);
+    type("1");
+    backspace();
+    sync.setTokensEditPostProcessor(null);
+    type("2");
+    assertTrue(lastSeenTokens.get().isEmpty());
+  }
+
+  @Test
   public void postProcessValueTokenRemoval() {
     // Such removes are processed with both onKeyPressed and
     // onKeyPressedLowPriority - and both may be passed the same tokens,


### PR DESCRIPTION
The main purpose of this postprocessor is allowing doing anything with the model (or cells, or mappers) after the Hybrid Synchronizer has finished all things with tokens (complete, transform, process comments, set focus). This allows even destroying a part of a model which initiated a post-processing (see tests). Any other approach (attach model listeners, design a special completion) will inevitably cause NPE or illegal state because of changing a model while tokens and cells operations are still running.