### PR TITLE
Selection escalated if lower-level selection found

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/position/Positions.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/position/Positions.java
@@ -29,6 +29,10 @@ public class Positions {
     return last != null && last.focused().get() && last.get(PositionHandler.PROPERTY).isEnd();
   }
 
+  public static boolean isOnePosition(Cell cell) {
+    return isHomePosition(cell) && isEndPosition(cell);
+  }
+
   public static boolean isFirstPosition(Cell cell) {
     Cell firstFocusable = Composites.firstFocusable(cell, true);
     if (firstFocusable == null) return false;

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionController.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionController.java
@@ -76,7 +76,7 @@ public class SelectionController {
     myLegacySelectionId = null;
   }
 
-  public Selection getLastSelection() {
+  Selection getLastSelection() {
     return myLastSelection;
   }
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionController.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionController.java
@@ -22,6 +22,7 @@ import jetbrains.jetpad.cell.CellPropertySpec;
 import jetbrains.jetpad.cell.TraitPropagator;
 import jetbrains.jetpad.cell.trait.CellTrait;
 import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
+import jetbrains.jetpad.model.event.CompositeRegistration;
 import jetbrains.jetpad.model.event.ListenerCaller;
 import jetbrains.jetpad.model.event.Listeners;
 
@@ -32,12 +33,15 @@ public class SelectionController {
 
   public static Registration install(CellContainer container) {
     SelectionController sm = new SelectionController();
-    return TraitPropagator.install(container, sm.trait(), HAS_SELECTION_CONTROLLER);
+    return new CompositeRegistration(TraitPropagator.install(container, sm.trait(), HAS_SELECTION_CONTROLLER),
+        sm.installLastUpdateTracker());
   }
 
   private SelectionId myLegacySelectionId = null;
 
   private Listeners<SelectionListener> myListeners = new Listeners<>();
+
+  private Selection myLastSelection;
 
   public Registration addListener(SelectionListener l) {
     return myListeners.add(l);
@@ -72,6 +76,10 @@ public class SelectionController {
     myLegacySelectionId = null;
   }
 
+  public Selection getLastSelection() {
+    return myLastSelection;
+  }
+
   private CellTrait trait(){
     return new CellTrait() {
       @Override
@@ -91,5 +99,24 @@ public class SelectionController {
         }
       }
     };
+  }
+
+  private Registration installLastUpdateTracker() {
+    return myListeners.add(new SelectionListener() {
+      @Override
+      public void onSelectionOpened(SelectionId id, Selection selection) {
+        myLastSelection = selection;
+      }
+
+      @Override
+      public void onSelectionChanged(SelectionId id, Selection selection) {
+        myLastSelection = selection;
+      }
+
+      @Override
+      public void onSelectionClosed(SelectionId id) {
+        myLastSelection = null;
+      }
+    });
   }
 }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
@@ -232,7 +232,7 @@ public class SelectionSupport<ItemT> {
             int focusIndex = -1;
             boolean focusOnFirst = true;
 
-            if (!mySelectedItems.contains(currentItem) && (cursorIsInSinglePossiblePos(currentCell) || hasLowerPrioritySelection(currentCell))) {
+            if (!mySelectedItems.contains(currentItem) && (Positions.isOnePosition(currentCell) || hasLowerPrioritySelection(currentCell))) {
               mySelectedItems.add(currentItem);
               focusIndex = currentIndex;
               focusOnFirst = false;
@@ -302,7 +302,7 @@ public class SelectionSupport<ItemT> {
             int focusIndex = -1;
             boolean focusOnFirst = true;
 
-            if (!mySelectedItems.contains(currentItem) && (cursorIsInSinglePossiblePos(currentCell) || hasLowerPrioritySelection(currentCell))) {
+            if (!mySelectedItems.contains(currentItem) && (Positions.isOnePosition(currentCell) || hasLowerPrioritySelection(currentCell))) {
               mySelectedItems.add(0, currentItem);
               focusIndex = currentIndex;
               consumed = true;
@@ -338,24 +338,21 @@ public class SelectionSupport<ItemT> {
     }
   }
 
-  private boolean cursorIsInSinglePossiblePos(Cell cell) {
-    return Positions.isHomePosition(cell) && Positions.isEndPosition(cell);
-  }
-
   private boolean hasLowerPrioritySelection(Cell cell) {
     return mySelectionController != null
-        ? isLowerPrioritySelection(cell, mySelectionController.getLastSelection())
-        : walkTreeCheckHasLowerSelection(cell);
+        ? hasLowerSelectionInController(cell)
+        : hasLowerSelectionInTree(cell);
   }
 
-  private boolean isLowerPrioritySelection(Cell cell, Selection selection) {
+  private boolean hasLowerSelectionInController(Cell cell) {
+    Selection selection = mySelectionController.getLastSelection();
     return selection != null
         && Composites.isDescendant(cell, selection.getStart())
         && Composites.isDescendant(cell, selection.getEnd());
 
   }
 
-  private boolean walkTreeCheckHasLowerSelection(Cell cell) {
+  private boolean hasLowerSelectionInTree(Cell cell) {
     SelectionSupport<?> selection = cell.get(SELECTION_SUPPORT);
     if (selection != null && !selection.selection().isEmpty()) {
       return true;
@@ -368,7 +365,7 @@ public class SelectionSupport<ItemT> {
     return false;
   }
 
-  boolean isLowerPrioritySelection() {
+  private boolean isLowerPrioritySelection() {
     Cell current = myTarget;
     while (true) {
       Cell parent = current.getParent();

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
@@ -232,7 +232,7 @@ public class SelectionSupport<ItemT> {
             int focusIndex = -1;
             boolean focusOnFirst = true;
 
-            if (!mySelectedItems.contains(currentItem) && Positions.isHomePosition(currentCell) && Positions.isEndPosition(currentCell)) {
+            if (!mySelectedItems.contains(currentItem) && (cursorIsInSinglePossiblePos(currentCell) || hasLowerPrioritySelection(currentCell))) {
               mySelectedItems.add(currentItem);
               focusIndex = currentIndex;
               focusOnFirst = false;
@@ -302,7 +302,7 @@ public class SelectionSupport<ItemT> {
             int focusIndex = -1;
             boolean focusOnFirst = true;
 
-            if (!mySelectedItems.contains(currentItem) && Positions.isHomePosition(currentCell) && Positions.isEndPosition(currentCell)) {
+            if (!mySelectedItems.contains(currentItem) && (cursorIsInSinglePossiblePos(currentCell) || hasLowerPrioritySelection(currentCell))) {
               mySelectedItems.add(0, currentItem);
               focusIndex = currentIndex;
               consumed = true;
@@ -336,6 +336,36 @@ public class SelectionSupport<ItemT> {
         }
       });
     }
+  }
+
+  private boolean cursorIsInSinglePossiblePos(Cell cell) {
+    return Positions.isHomePosition(cell) && Positions.isEndPosition(cell);
+  }
+
+  private boolean hasLowerPrioritySelection(Cell cell) {
+    return mySelectionController != null
+        ? isLowerPrioritySelection(cell, mySelectionController.getLastSelection())
+        : walkTreeCheckHasLowerSelection(cell);
+  }
+
+  private boolean isLowerPrioritySelection(Cell cell, Selection selection) {
+    return selection != null
+        && Composites.isDescendant(cell, selection.getStart())
+        && Composites.isDescendant(cell, selection.getEnd());
+
+  }
+
+  private boolean walkTreeCheckHasLowerSelection(Cell cell) {
+    SelectionSupport<?> selection = cell.get(SELECTION_SUPPORT);
+    if (selection != null && !selection.selection().isEmpty()) {
+      return true;
+    }
+    for (Cell child : cell.children()) {
+      if (hasLowerPrioritySelection(child)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   boolean isLowerPrioritySelection() {

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/selection/SelectionControllerLegacyTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/selection/SelectionControllerLegacyTest.java
@@ -47,7 +47,9 @@ public class SelectionControllerLegacyTest extends EditingTestCase {
       new TestTree("a",
         new TestTree("c"),
         new TestTree("d")),
-      new TestTree("b"));
+      new TestTree("b",
+        new TestTree("e"),
+        new TestTree("f")));
     rootMapper = new TestTreeMapper(root);
     rootMapper.attachRoot();
     myCellContainer.root.children().add(rootMapper.getTarget());
@@ -90,10 +92,19 @@ public class SelectionControllerLegacyTest extends EditingTestCase {
     press(Key.RIGHT, ModifierKey.SHIFT);
     assertEquals(2, selectionHistory.size()); // [c, c], [c, d]
     press(Key.RIGHT, ModifierKey.SHIFT);
-    assertEquals(3, selectionHistory.size()); // [c, c], [c, d], [b, b]
+    assertEquals(4, selectionHistory.size()); // [c, c], [c, d], [a, a], [a, b]
 
     CellActions.toFirstFocusable(rootMapper.getTarget()).run();
     assertTrue(selectionHistory.isEmpty());
+  }
+
+  @Test
+  public void backwardRange() {
+    CellActions.toLastFocusable(rootMapper.getTarget()).run();
+    press(Key.LEFT, ModifierKey.SHIFT);
+    assertEquals(2, selectionHistory.size());
+    press(Key.LEFT, ModifierKey.SHIFT);
+    assertEquals(4, selectionHistory.size());
   }
 
   private static class TestCell extends VerticalCell {


### PR DESCRIPTION
Effect is better visible in apps that have both hybrid and projectional editors. If you select some tokens up to the line end, and then continue selection, tokens selections is promoted to projectional selection, and also the next line selected. Earlier tokens selection was dropped.

**Warning:** this will break tests of https://github.com/JetBrains/jetpad-projectional/pull/247. After you accept latter, please give me some time to merge from master and change tests. 