### PR TITLE
DP-1136 Fixed uncommenting a comment with a nested comment

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/text/CellTextEditor.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/CellTextEditor.java
@@ -39,6 +39,11 @@ abstract class CellTextEditor implements TextEditor {
   }
 
   @Override
+  public boolean isAttached() {
+    return myCell.isAttached();
+  }
+
+  @Override
   public boolean isFirstAllowed() {
     return myCell.get(TextEditing.FIRST_ALLOWED);
   }

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -165,8 +165,10 @@ public class TextEditingTrait extends TextNavigationTrait {
 
     String text = "" + event.getKeyChar();
     pasteText(editor, text);
-    editor.scrollToCaret();
-    onAfterType(editor);
+    if (editor.isAttached()) {
+      editor.scrollToCaret();
+      onAfterType(editor);
+    }
     event.consume();
   }
 
@@ -178,7 +180,9 @@ public class TextEditingTrait extends TextNavigationTrait {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     clearSelection(editor);
     pasteText(editor, content.get(ContentKinds.SINGLE_LINE_TEXT));
-    onAfterPaste(editor);
+    if (editor.isAttached()) {
+      onAfterPaste(editor);
+    }
     event.consume();
   }
 
@@ -211,7 +215,9 @@ public class TextEditingTrait extends TextNavigationTrait {
     } else {
       setText(editor, "" + text);
     }
-    editor.caretPosition().set(caret + text.length());
+    if (editor.isAttached()) {
+      editor.caretPosition().set(caret + text.length());
+    }
   }
 
   protected void setText(CellTextEditor editor, String text) {

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditor.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditor.java
@@ -23,6 +23,8 @@ import jetbrains.jetpad.model.property.Property;
 import jetbrains.jetpad.model.property.ReadableProperty;
 
 public interface TextEditor {
+  boolean isAttached();
+
   ReadableProperty<Boolean> focused();
 
   Property<String> text();

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -182,7 +182,7 @@ class TokenCellTraits {
           TextCell textCell = (TextCell) cell;
           String text = textCell.text().get();
           String prefix = commentToken.getPrefix();
-          if (!text.contains(prefix)) {
+          if (!text.startsWith(prefix)) {
             tokenOperations(cell).replaceCommentToken(cell, textCell).run();
             event.consume();
             return;

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -1200,6 +1200,16 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void uncommentWithInnerComment() {
+    setTokens(integer(1), new CommentToken("#", " + 2 # + 3"));
+    select(1, true);
+
+    del();
+
+    assertTokens(integer(1), Tokens.PLUS, integer(2), new CommentToken("#", " + 3"));
+  }
+
+  @Test
   public void typeBeforeComment() {
     setTokens(new CommentToken("#", " + 3"));
     select(0, true);
@@ -1207,6 +1217,16 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     type("1");
 
     assertTokens(integer(1), new CommentToken("#", " + 3"));
+  }
+
+  @Test
+  public void pasteBeforeComment() {
+    setTokens(new CommentToken("#", "test"));
+    select(0, true);
+
+    paste("1");
+
+    assertTokens(integer(1), new CommentToken("#", "test"));
   }
 
   @Test


### PR DESCRIPTION
Changes in `TextEditingTrait` caused by possible processed token removal (resulting in cell detach). Earlier current token also had a chance to be removed, but this was happening in other paths which took this into a consideration and no error was encountered.

Changes in `TextEditingTrait` are covered by new and some old tests.