### PR TITLE
List proj sync: can replace items with new instead of removing

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
@@ -15,6 +15,8 @@
  */
 package jetbrains.jetpad.projectional.cell;
 
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.base.Runnables;
 import jetbrains.jetpad.cell.Cell;
@@ -47,6 +49,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   static final CellTraitPropertySpec<ItemHandler> ITEM_HANDLER = new CellTraitPropertySpec<>("itemHandler");
 
   private ObservableList<SourceItemT> mySource;
+  private Predicate<SourceItemT> myReplaceWithNewOnRemove = Predicates.alwaysFalse();
 
   ProjectionalObservableListSynchronizer(
       Mapper<? extends ContextT, ? extends Cell> mapper,
@@ -139,7 +142,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   }
 
   private void keyPressedInChild(KeyEvent event) {
-    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem()) {
+    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem(), myReplaceWithNewOnRemove) {
       @Override
       protected SourceItemT newItem() {
         return ProjectionalObservableListSynchronizer.this.newItem();
@@ -278,6 +281,14 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
 
   private boolean isEmpty(int index) {
     return Cells.isEmpty(getChildCells().get(index));
+  }
+
+  @Override
+  public void replaceWithNewOnRemove(Predicate<SourceItemT> shouldReplace) {
+    if (!canCreateNewItem()) {
+      throw new IllegalStateException("Can't create new items");
+    }
+    myReplaceWithNewOnRemove = shouldReplace;
   }
 
   interface ItemHandler {

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
@@ -49,7 +49,6 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   static final CellTraitPropertySpec<ItemHandler> ITEM_HANDLER = new CellTraitPropertySpec<>("itemHandler");
 
   private ObservableList<SourceItemT> mySource;
-  private boolean myReplaceNonemptyWithNewOnRemove;
 
   ProjectionalObservableListSynchronizer(
       Mapper<? extends ContextT, ? extends Cell> mapper,
@@ -142,7 +141,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   }
 
   private void keyPressedInChild(KeyEvent event) {
-    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem(), replaceOnRemovePredicate()) {
+    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem(), replaceWithNewOnDel()) {
       @Override
       protected SourceItemT newItem() {
         return ProjectionalObservableListSynchronizer.this.newItem();
@@ -220,8 +219,8 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
     }.handleKey(currentCell(), event);
   }
 
-  private Predicate<Cell> replaceOnRemovePredicate() {
-    return myReplaceNonemptyWithNewOnRemove ? new Predicate<Cell>() {
+  private Predicate<Cell> replaceWithNewOnDel() {
+    return canCreateNewItem() ? new Predicate<Cell>() {
       @Override
       public boolean apply(Cell cell) {
         return !Cells.isEmpty(cell);
@@ -290,14 +289,6 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
 
   private boolean isEmpty(int index) {
     return Cells.isEmpty(getChildCells().get(index));
-  }
-
-  @Override
-  public void setReplaceNonemptyWithNewOnRemove(boolean replaceWithNew) {
-    if (!canCreateNewItem()) {
-      throw new IllegalStateException("Can't create new items");
-    }
-    myReplaceNonemptyWithNewOnRemove = replaceWithNew;
   }
 
   interface ItemHandler {

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
@@ -161,9 +161,4 @@ class ProjectionalPropertySynchronizer<ContextT, SourceItemT> extends BaseProjec
       getTarget().dispatch(new Event(), Cells.BECAME_EMPTY);
     }
   }
-
-  @Override
-  public void setReplaceNonemptyWithNewOnRemove(boolean replaceWithNew) {
-    throw new UnsupportedOperationException("Use onLastItemDeleted instead");
-  }
 }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.projectional.cell;
 
+import com.google.common.base.Predicate;
 import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.TextCell;
@@ -160,5 +161,10 @@ class ProjectionalPropertySynchronizer<ContextT, SourceItemT> extends BaseProjec
     if (getTarget().get(ProjectionalSynchronizers.DELETE_ON_EMPTY)) {
       getTarget().dispatch(new Event(), Cells.BECAME_EMPTY);
     }
+  }
+
+  @Override
+  public void replaceWithNewOnRemove(Predicate<SourceItemT> shouldReplace) {
+    throw new UnsupportedOperationException("Use onLastItemDeleted instead");
   }
 }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalPropertySynchronizer.java
@@ -15,7 +15,6 @@
  */
 package jetbrains.jetpad.projectional.cell;
 
-import com.google.common.base.Predicate;
 import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.TextCell;
@@ -164,7 +163,7 @@ class ProjectionalPropertySynchronizer<ContextT, SourceItemT> extends BaseProjec
   }
 
   @Override
-  public void replaceWithNewOnRemove(Predicate<SourceItemT> shouldReplace) {
+  public void setReplaceNonemptyWithNewOnRemove(boolean replaceWithNew) {
     throw new UnsupportedOperationException("Use onLastItemDeleted instead");
   }
 }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -37,7 +37,6 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void disablePlaceholder();
   void setItemFactory(Supplier<SourceT> itemFactory);
   void setSeparator(Character ch);
-  void setReplaceNonemptyWithNewOnRemove(boolean replaceWithNew);
 
   SourceT getFocusedItem();
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -16,11 +16,10 @@
 package jetbrains.jetpad.projectional.cell;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
+import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.event.ContentKind;
 import jetbrains.jetpad.mapper.RoleSynchronizer;
-import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.projectional.generic.RoleCompletion;
 
 import java.util.List;
@@ -38,7 +37,7 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void disablePlaceholder();
   void setItemFactory(Supplier<SourceT> itemFactory);
   void setSeparator(Character ch);
-  void replaceWithNewOnRemove(Predicate<SourceT> shouldReplace);
+  void setReplaceNonemptyWithNewOnRemove(boolean replaceWithNew);
 
   SourceT getFocusedItem();
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.projectional.cell;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import jetbrains.jetpad.event.ContentKind;
 import jetbrains.jetpad.mapper.RoleSynchronizer;
@@ -37,6 +38,7 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void disablePlaceholder();
   void setItemFactory(Supplier<SourceT> itemFactory);
   void setSeparator(Character ch);
+  void replaceWithNewOnRemove(Predicate<SourceT> shouldReplace);
 
   SourceT getFocusedItem();
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
@@ -29,10 +29,10 @@ public abstract class CollectionEditor<ItemT, ViewT> {
   private List<ViewT> myViews;
   private Property<ItemT> myForDeletion;
   private boolean myCanCreateNew;
-  private Predicate<ItemT> myReplaceWithNewOnRemove;
+  private Predicate<ViewT> myReplaceWithNewOnRemove;
 
   protected CollectionEditor(List<ItemT> items, List<ViewT> views, Property<ItemT> forDeletion, boolean canCreateNew,
-      Predicate<ItemT> replaceWithNewOnRemove) {
+      Predicate<ViewT> replaceWithNewOnRemove) {
     myItems = items;
     myViews = views;
     myForDeletion = forDeletion;
@@ -131,7 +131,7 @@ public abstract class CollectionEditor<ItemT, ViewT> {
     }
 
     if (isDeleteEvent(event)) {
-      if (myReplaceWithNewOnRemove.apply(myItems.get(index))) {
+      if (myReplaceWithNewOnRemove.apply(myViews.get(index))) {
         myItems.set(index, newItem());
         selectHome(index);
       } else {

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.jetpad.projectional.generic;
 
+import com.google.common.base.Predicate;
 import jetbrains.jetpad.event.Key;
 import jetbrains.jetpad.event.KeyEvent;
 import jetbrains.jetpad.event.KeyStrokeSpecs;
@@ -28,12 +29,15 @@ public abstract class CollectionEditor<ItemT, ViewT> {
   private List<ViewT> myViews;
   private Property<ItemT> myForDeletion;
   private boolean myCanCreateNew;
+  private Predicate<ItemT> myReplaceWithNewOnRemove;
 
-  protected CollectionEditor(List<ItemT> items, List<ViewT> views, Property<ItemT> forDeletion, boolean canCreateNew) {
+  protected CollectionEditor(List<ItemT> items, List<ViewT> views, Property<ItemT> forDeletion, boolean canCreateNew,
+      Predicate<ItemT> replaceWithNewOnRemove) {
     myItems = items;
     myViews = views;
     myForDeletion = forDeletion;
     myCanCreateNew = canCreateNew;
+    myReplaceWithNewOnRemove = replaceWithNewOnRemove;
   }
 
   protected abstract ItemT newItem();
@@ -127,10 +131,14 @@ public abstract class CollectionEditor<ItemT, ViewT> {
     }
 
     if (isDeleteEvent(event)) {
-      myItems.remove(index);
-      selectAfterClear(index);
+      if (myReplaceWithNewOnRemove.apply(myItems.get(index))) {
+        myItems.set(index, newItem());
+        selectHome(index);
+      } else {
+        myItems.remove(index);
+        selectAfterClear(index);
+      }
       event.consume();
-      return;
     }
   }
 
@@ -146,11 +154,11 @@ public abstract class CollectionEditor<ItemT, ViewT> {
     }
   }
 
-  protected boolean isDeleteEvent(KeyEvent event) {
+  private boolean isDeleteEvent(KeyEvent event) {
     return isAnyPositionDeleteEvent(event) || isSimpleDeleteEvent(event);
   }
 
-  protected boolean isSimpleDeleteEvent(KeyEvent event) {
+  private boolean isSimpleDeleteEvent(KeyEvent event) {
     return event.is(Key.BACKSPACE) || event.is(Key.DELETE);
   }
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/generic/CollectionEditor.java
@@ -29,15 +29,15 @@ public abstract class CollectionEditor<ItemT, ViewT> {
   private List<ViewT> myViews;
   private Property<ItemT> myForDeletion;
   private boolean myCanCreateNew;
-  private Predicate<ViewT> myReplaceWithNewOnRemove;
+  private Predicate<ViewT> myReplaceWithNewOnDel;
 
   protected CollectionEditor(List<ItemT> items, List<ViewT> views, Property<ItemT> forDeletion, boolean canCreateNew,
-      Predicate<ViewT> replaceWithNewOnRemove) {
+      Predicate<ViewT> replaceWithNewOnDel) {
     myItems = items;
     myViews = views;
     myForDeletion = forDeletion;
     myCanCreateNew = canCreateNew;
-    myReplaceWithNewOnRemove = replaceWithNewOnRemove;
+    myReplaceWithNewOnDel = replaceWithNewOnDel;
   }
 
   protected abstract ItemT newItem();
@@ -131,7 +131,7 @@ public abstract class CollectionEditor<ItemT, ViewT> {
     }
 
     if (isDeleteEvent(event)) {
-      if (myReplaceWithNewOnRemove.apply(myViews.get(index))) {
+      if (myReplaceWithNewOnDel.apply(myViews.get(index))) {
         myItems.set(index, newItem());
         selectHome(index);
       } else {

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -16,6 +16,7 @@
 package jetbrains.jetpad.projectional.cell;
 
 import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -1094,6 +1095,21 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     rootMapper.mySynchronizer.setOnLastItemDeleted(Runnables.EMPTY);
     rootMapper.mySynchronizer.disablePlaceholder();
     rootMapper.mySynchronizer.setOnLastItemDeleted(null);
+  }
+
+  @Test
+  public void replaceWithNewOnRemove() {
+    rootMapper.mySynchronizer.replaceWithNewOnRemove(new Predicate<Child>() {
+      @Override
+      public boolean apply(Child child) {
+        return !(child instanceof EmptyChild);
+      }
+    });
+    container.children.add(new NonEmptyChild());
+    selectChild(0);
+    backspace();
+    backspace();
+    assertTrue(container.children.get(0) instanceof EmptyChild);
   }
 
   private Child get(int index) {

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -16,7 +16,6 @@
 package jetbrains.jetpad.projectional.cell;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -1099,12 +1098,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
 
   @Test
   public void replaceWithNewOnRemove() {
-    rootMapper.mySynchronizer.replaceWithNewOnRemove(new Predicate<Child>() {
-      @Override
-      public boolean apply(Child child) {
-        return !(child instanceof EmptyChild);
-      }
-    });
+    rootMapper.mySynchronizer.setReplaceNonemptyWithNewOnRemove(true);
     container.children.add(new NonEmptyChild());
     selectChild(0);
     backspace();

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -298,14 +298,15 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void lastItemDelete() {
+  public void lastItemReplaceWithEmtpy() {
     container.children.add(new NonEmptyChild());
     selectChild(0);
 
     backspace();
     backspace();
 
-    assertTrue(container.children.isEmpty());
+    assertEquals(1, container.children.size());
+    assertTrue(get(0) instanceof EmptyChild);
   }
 
   @Test
@@ -320,7 +321,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void deleteSelectionInsideIndent() {
+  public void replaceSelectionWithEmptyInsideIndent() {
     CompositeChild cc = new CompositeChild();
     cc.children.add(new IndentChild());
     container.children.add(cc);
@@ -330,7 +331,8 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     backspace();
     backspace();
 
-    assertEquals(0, cc.children.size());
+    assertTrue(cc.children.get(0) instanceof EmptyChild);
+    assertEquals(1, cc.children.size());
   }
 
   @Test
@@ -345,7 +347,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void tailItemDelete() {
+  public void tailItemReplaceWithEmpty() {
     container.children.addAll(Arrays.asList(new NonEmptyChild(), new NonEmptyChild()));
 
     selectChild(1);
@@ -354,19 +356,21 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     del();
     del();
 
-    assertFocusedEnd(0);
+    assertTrue(get(1) instanceof EmptyChild);
+    assertFocusedEnd(1);
   }
 
 
   @Test
-  public void tailItemDeleteManyItems() {
+  public void tailItemReplaceWithEmptyManyItems() {
     container.children.addAll(Arrays.asList(new NonEmptyChild(), new NonEmptyChild(), new NonEmptyChild()));
 
     selectChild(2);
 
     press(Key.DELETE, ModifierKey.CONTROL);
 
-    assertFocusedEnd(1) ;
+    assertTrue(get(2) instanceof EmptyChild);
+    assertFocusedEnd(2) ;
   }
 
   @Test
@@ -1098,7 +1102,6 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
 
   @Test
   public void replaceWithNewOnRemove() {
-    rootMapper.mySynchronizer.setReplaceNonemptyWithNewOnRemove(true);
     container.children.add(new NonEmptyChild());
     selectChild(0);
     backspace();


### PR DESCRIPTION
This is needed to leave empty line when you remove some statement. New feature is not added to property synchronizer simply because it's not needed.