### PR TITLE
Fixed OutOfBounds exception on items remove

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/selection/SelectionSupport.java
@@ -94,7 +94,16 @@ public class SelectionSupport<ItemT> {
           if (!mySelectedItems.isEmpty()) {
             int startIndex = mySource.indexOf(mySelectedItems.get(0));
             int endIndex = mySource.indexOf(mySelectedItems.get(mySelectedItems.size() - 1));
-            mySelectionController.updateLegacySelection(myTargetList.get(startIndex), myTargetList.get(endIndex));
+            /*
+             * Because list clear may be implemented with iterate-remove, intermediate states
+             * are possible when selection (mySelectedItems) contains items already removed
+             * from the model (mySource). We bypass such cases.
+             */
+            if (startIndex != -1 && endIndex != -1) {
+              mySelectionController.updateLegacySelection(myTargetList.get(startIndex), myTargetList.get(endIndex));
+            } else if (!myChangingSelection) {
+              throw new IllegalStateException("Intermediate state outside changing selection encountered. Selected items: " + mySelectedItems);
+            }
           } else {
             mySelectionController.closeLegacySelection();
           }

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/selection/SelectionControllerLegacyTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/selection/SelectionControllerLegacyTest.java
@@ -151,6 +151,16 @@ public class SelectionControllerLegacyTest extends EditingTestCase {
     assertHistory(selection(get(z), get(z)), selection(get(y), get(z)), selection(get(x), get(x)), selection(get(g), get(x)));
   }
 
+  @Test
+  public void removeMultiple() {
+    CellActions.toHome(get(d).labelCell).run();
+    press(Key.DOWN, ModifierKey.SHIFT);
+    press(Key.DOWN, ModifierKey.SHIFT);
+
+    del();
+    assertEquals(2, a.branches.size());
+  }
+
   private TestCell get(TestTree source) {
     return (TestCell)mappingContext.getMapper(rootMapper, source).getTarget();
   }


### PR DESCRIPTION
This happened on multiple items delete in projectional syncronizer. Please see comment in `SelectionSupport` for details.

Because we can't change `ArrayList` implementation, we have to allow `mySelectionController` being inconsistent for some time.

If you run a test without a fix, it will fail, but you will see another exception. That's because some `finally` block throws another one which suppresses original.