### PR TITLE
DP-1184 Type before comment does not cause retokenizing

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
@@ -30,10 +30,7 @@ import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.completion.BaseCompletionParameters;
 import jetbrains.jetpad.completion.CompletionItem;
 import jetbrains.jetpad.completion.CompletionParameters;
-import jetbrains.jetpad.event.Event;
-import jetbrains.jetpad.event.Key;
-import jetbrains.jetpad.event.KeyEvent;
-import jetbrains.jetpad.event.ModifierKey;
+import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 import jetbrains.jetpad.values.Color;
 
@@ -55,7 +52,7 @@ class ValidTextEditingTrait extends TextEditingTrait {
 
   @Override
   public void onAdd(Cell cell) {
-    validate(cell);
+    validate(cell, null);
   }
 
   @Override
@@ -82,17 +79,18 @@ class ValidTextEditingTrait extends TextEditingTrait {
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> e) {
     if (prop == TextCell.TEXT) {
-      validate(cell);
+      validate(cell, new PropertyChangeEventWrapper(e));
     }
     super.onPropertyChanged(cell, prop, e);
   }
 
-  private void validate(Cell cell) {
+  private void validate(Cell cell, Event cause) {
     CellTextEditor editor = TextEditing.cellTextEditor(cell);
     boolean valid = isValid(editor);
     MessageController.setBroken(cell, valid ? null : "Cannot resolve '" + TextEditing.text(editor) + '\'');
     if (!valid) {
-      cell.dispatch(new Event(), Cells.BECAME_INVALID);
+      Event becameInvalidEvent = cause != null ? new DerivedEvent(cause) : new Event();
+      cell.dispatch(becameInvalidEvent, Cells.BECAME_INVALID);
     }
   }
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/ValidTextEditingTrait.java
@@ -79,7 +79,7 @@ class ValidTextEditingTrait extends TextEditingTrait {
   @Override
   public void onPropertyChanged(Cell cell, CellPropertySpec<?> prop, PropertyChangeEvent<?> e) {
     if (prop == TextCell.TEXT) {
-      validate(cell, new PropertyChangeEventWrapper(e));
+      validate(cell, new PropertyChangeEventWrapper<>(e));
     }
     super.onPropertyChanged(cell, prop, e);
   }

--- a/event/src/main/java/jetbrains/jetpad/event/DerivedEvent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/DerivedEvent.java
@@ -16,9 +16,13 @@
 package jetbrains.jetpad.event;
 
 public class DerivedEvent extends Event {
-  public final Event cause;
+  private final Event myCause;
 
   public DerivedEvent(Event cause) {
-    this.cause = cause;
+    myCause = cause;
+  }
+
+  public Event getCause() {
+    return myCause;
   }
 }

--- a/event/src/main/java/jetbrains/jetpad/event/DerivedEvent.java
+++ b/event/src/main/java/jetbrains/jetpad/event/DerivedEvent.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.event;
+
+public class DerivedEvent extends Event {
+  public final Event cause;
+
+  public DerivedEvent(Event cause) {
+    this.cause = cause;
+  }
+}

--- a/event/src/main/java/jetbrains/jetpad/event/Event.gwt.xml
+++ b/event/src/main/java/jetbrains/jetpad/event/Event.gwt.xml
@@ -2,6 +2,7 @@
   <inherits name="com.google.gwt.query.Query"/>
   <inherits name="jetbrains.jetpad.base.Base"/>
   <inherits name="jetbrains.jetpad.geometry.Geometry"/>
+  <inherits name="jetbrains.jetpad.model.Model"/>
   <source path="">
     <exclude name="awt/**" />
   </source>

--- a/event/src/main/java/jetbrains/jetpad/event/Events.java
+++ b/event/src/main/java/jetbrains/jetpad/event/Events.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.event;
+
+public class Events {
+  public static Event getCause(Event e) {
+    while (e instanceof DerivedEvent) {
+      e = ((DerivedEvent) e).cause;
+    }
+    return e;
+  }
+}

--- a/event/src/main/java/jetbrains/jetpad/event/Events.java
+++ b/event/src/main/java/jetbrains/jetpad/event/Events.java
@@ -18,7 +18,7 @@ package jetbrains.jetpad.event;
 public class Events {
   public static Event getCause(Event e) {
     while (e instanceof DerivedEvent) {
-      e = ((DerivedEvent) e).cause;
+      e = ((DerivedEvent) e).getCause();
     }
     return e;
   }

--- a/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
+++ b/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
@@ -18,9 +18,17 @@ package jetbrains.jetpad.event;
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
 public class PropertyChangeEventWrapper extends Event {
-  public final PropertyChangeEvent<?> event;
+  private final PropertyChangeEvent<?> myEvent;
 
   public PropertyChangeEventWrapper(PropertyChangeEvent<?> event) {
-    this.event = event;
+    myEvent = event;
+  }
+
+  public Object getOldValue() {
+    return myEvent.getOldValue();
+  }
+
+  public Object getNewValue() {
+    return myEvent.getNewValue();
   }
 }

--- a/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
+++ b/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2012-2016 JetBrains s.r.o
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.jetpad.event;
+
+import jetbrains.jetpad.model.property.PropertyChangeEvent;
+
+public class PropertyChangeEventWrapper extends Event {
+  public final PropertyChangeEvent<?> event;
+
+  public PropertyChangeEventWrapper(PropertyChangeEvent<?> event) {
+    this.event = event;
+  }
+}

--- a/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
+++ b/event/src/main/java/jetbrains/jetpad/event/PropertyChangeEventWrapper.java
@@ -17,18 +17,14 @@ package jetbrains.jetpad.event;
 
 import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
-public class PropertyChangeEventWrapper extends Event {
-  private final PropertyChangeEvent<?> myEvent;
+public class PropertyChangeEventWrapper<ValueT> extends Event {
+  private final PropertyChangeEvent<ValueT> myEvent;
 
-  public PropertyChangeEventWrapper(PropertyChangeEvent<?> event) {
+  public PropertyChangeEventWrapper(PropertyChangeEvent<ValueT> event) {
     myEvent = event;
   }
 
-  public Object getOldValue() {
-    return myEvent.getOldValue();
-  }
-
-  public Object getNewValue() {
-    return myEvent.getNewValue();
+  public PropertyChangeEvent<ValueT> getEvent() {
+    return myEvent;
   }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -191,7 +191,7 @@ class TokenCellTraits {
     private boolean isUncomment(Event e, String prefix) {
       Event cause = Events.getCause(e);
       if (cause instanceof PropertyChangeEventWrapper) {
-        PropertyChangeEventWrapper event = (PropertyChangeEventWrapper) cause;
+        PropertyChangeEvent<?> event = ((PropertyChangeEventWrapper) cause).getEvent();
         if (event.getOldValue() instanceof String && event.getNewValue() instanceof String) {
           String oldText = (String) event.getOldValue();
           String newText = (String) event.getNewValue();

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -30,13 +30,11 @@ import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
 import jetbrains.jetpad.cell.trait.CompositeCellTrait;
 import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.completion.CompletionItem;
-import jetbrains.jetpad.event.Event;
-import jetbrains.jetpad.event.Key;
-import jetbrains.jetpad.event.KeyEvent;
-import jetbrains.jetpad.event.KeyStrokeSpecs;
+import jetbrains.jetpad.event.*;
 import jetbrains.jetpad.hybrid.parser.CommentToken;
 import jetbrains.jetpad.hybrid.parser.ErrorToken;
 import jetbrains.jetpad.hybrid.parser.Token;
+import jetbrains.jetpad.model.property.PropertyChangeEvent;
 
 import java.util.List;
 
@@ -179,11 +177,8 @@ class TokenCellTraits {
         if (current instanceof CommentToken) {
           CommentToken commentToken = (CommentToken) current;
 
-          TextCell textCell = (TextCell) cell;
-          String text = textCell.text().get();
-          String prefix = commentToken.getPrefix();
-          if (!text.startsWith(prefix)) {
-            tokenOperations(cell).replaceCommentToken(cell, textCell).run();
+          if (isUncomment(event, commentToken.getPrefix())) {
+            tokenOperations(cell).replaceCommentToken(cell, (TextCell) cell).run();
             event.consume();
             return;
           }
@@ -191,6 +186,19 @@ class TokenCellTraits {
       }
 
       super.onCellTraitEvent(cell, spec, event);
+    }
+
+    private boolean isUncomment(Event e, String prefix) {
+      Event cause = Events.getCause(e);
+      if (cause instanceof PropertyChangeEventWrapper) {
+        PropertyChangeEvent<?> event = ((PropertyChangeEventWrapper) cause).event;
+        if (event.getOldValue() instanceof String && event.getNewValue() instanceof String) {
+          String oldText = (String) event.getOldValue();
+          String newText = (String) event.getNewValue();
+          return oldText.endsWith(newText) && oldText.startsWith(prefix) && !newText.startsWith(prefix);
+        }
+      }
+      return false;
     }
 
     @Override

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenCellTraits.java
@@ -191,7 +191,7 @@ class TokenCellTraits {
     private boolean isUncomment(Event e, String prefix) {
       Event cause = Events.getCause(e);
       if (cause instanceof PropertyChangeEventWrapper) {
-        PropertyChangeEvent<?> event = ((PropertyChangeEventWrapper) cause).event;
+        PropertyChangeEventWrapper event = (PropertyChangeEventWrapper) cause;
         if (event.getOldValue() instanceof String && event.getNewValue() instanceof String) {
           String oldText = (String) event.getOldValue();
           String newText = (String) event.getNewValue();

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -1214,9 +1214,9 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     setTokens(new CommentToken("#", " + 3"));
     select(0, true);
 
-    type("1");
+    type("12");
 
-    assertTokens(integer(1), new CommentToken("#", " + 3"));
+    assertTokens(integer(12), new CommentToken("#", " + 3"));
   }
 
   @Test


### PR DESCRIPTION
Only uncommenting (removing front `#` with del or backspace) should cause comment retokenizing. Typing anything before comment should be handled as for other tokens (with side transformation in `ValidTextEditingTrait`).