### PR TITLE
allow more empty lines at the end

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalObservableListSynchronizer.java
@@ -46,16 +46,19 @@ import java.util.List;
 class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends BaseProjectionalSynchronizer<ObservableList<SourceItemT>, ContextT, SourceItemT> {
   static final CellTraitPropertySpec<ItemHandler> ITEM_HANDLER = new CellTraitPropertySpec<>("itemHandler");
 
-  private ObservableList<SourceItemT> mySource;
+  private final ObservableList<SourceItemT> mySource;
+  private final int myNumAllowedEmptyLines;
 
   ProjectionalObservableListSynchronizer(
       Mapper<? extends ContextT, ? extends Cell> mapper,
       ObservableList<SourceItemT> source,
       Cell target,
       List<Cell> targetList,
-      MapperFactory<SourceItemT, Cell> factory) {
+      MapperFactory<SourceItemT, Cell> factory,
+      int numAllowedEmptyLines) {
     super(mapper, source, target, targetList, factory);
     mySource = source;
+    myNumAllowedEmptyLines = numAllowedEmptyLines;
   }
 
   @Override
@@ -139,7 +142,7 @@ class ProjectionalObservableListSynchronizer<ContextT, SourceItemT> extends Base
   }
 
   private void keyPressedInChild(KeyEvent event) {
-    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem()) {
+    new CollectionEditor<SourceItemT, Cell>(mySource, getChildCells(), getForDeletion(), canCreateNewItem(), myNumAllowedEmptyLines) {
       @Override
       protected SourceItemT newItem() {
         return ProjectionalObservableListSynchronizer.this.newItem();

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalSynchronizers.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalSynchronizers.java
@@ -51,9 +51,25 @@ public class ProjectionalSynchronizers {
 
   public static <ContextT, SourceT> ProjectionalRoleSynchronizer<ContextT, SourceT> forRole(
       Mapper<? extends ContextT, ? extends Cell> mapper,
+      ObservableList<SourceT> source, Cell target,
+      MapperFactory<SourceT, Cell> factory,
+      int numAllowedEmptyLines) {
+    return forRole(mapper, source, target, target.children(), factory, numAllowedEmptyLines);
+  }
+
+  public static <ContextT, SourceT> ProjectionalRoleSynchronizer<ContextT, SourceT> forRole(
+      Mapper<? extends ContextT, ? extends Cell> mapper,
       ObservableList<SourceT> source, Cell target, List<Cell> targetList,
       MapperFactory<SourceT, Cell> factory) {
-    return new ProjectionalObservableListSynchronizer<>(mapper, source, target, targetList, factory);
+    return forRole(mapper, source, target, targetList, factory, 0);
+  }
+
+  public static <ContextT, SourceT> ProjectionalRoleSynchronizer<ContextT, SourceT> forRole(
+      Mapper<? extends ContextT, ? extends Cell> mapper,
+      ObservableList<SourceT> source, Cell target, List<Cell> targetList,
+      MapperFactory<SourceT, Cell> factory,
+      int numAllowedEmptyLines) {
+    return new ProjectionalObservableListSynchronizer<>(mapper, source, target, targetList, factory, numAllowedEmptyLines);
   }
 
   public static <ContextT, SourceT> ProjectionalRoleSynchronizer<ContextT, SourceT> forSingleRole(


### PR DESCRIPTION
It will allow having more empty lines at the end of the cell on Enter so that it's easier to enter, for example, two functions with two empty lines between them (in accordance with the python standard).
