### PR TITLE
DP-1188

### DIFF
--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/ParsingHybridPropertyTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/ParsingHybridPropertyTest.java
@@ -163,6 +163,17 @@ public class ParsingHybridPropertyTest extends BaseTestCase {
   }
 
   @Test
+  public void previousFormatting() {
+    mySourceTokens.add(new IdentifierToken("x"));
+    mySourceTokens.add(Tokens.LP);
+    mySourceTokens.add(Tokens.RP);
+    assertSame(myProp.getTokens().get(1), Tokens.LP_CALL);
+
+    mySourceTokens.add(Tokens.MUL);
+    assertSame(myProp.getTokens().get(1), Tokens.LP_CALL);
+  }
+
+  @Test
   public void withListener() {
     Registration r = myProp.addHandler(new EventHandler<PropertyChangeEvent<Expr>>() {
       @Override

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/PrettyHybridPropertyTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/PrettyHybridPropertyTest.java
@@ -223,6 +223,20 @@ public class PrettyHybridPropertyTest extends BaseTestCase {
   }
 
   @Test
+  public void olderPretty() {
+    init();
+    setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP);
+    assertSync();
+    assertSame(Tokens.LP_CALL, prop.getTokens().get(1));
+    assertSame(Tokens.LP_CALL, source.get(1).token);
+
+    addTokens(Tokens.MUL);
+    assertSync();
+    assertSame(Tokens.LP_CALL, prop.getTokens().get(1));
+    assertSame(Tokens.LP_CALL, source.get(1).token);
+  }
+
+  @Test
   public void reprintWithListener() {
     init();
     final Value<Integer> sourceChanges = new Value<>(0);

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridEditorExternalTokensChangeTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/SimpleHybridEditorExternalTokensChangeTest.java
@@ -66,7 +66,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void addMakeIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
     container.sourceTokens.add(2, Tokens.RP);
-    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, Tokens.RP, comment("test"));
   }
 
   @Test
@@ -80,7 +80,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void removeMakeIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
     container.sourceTokens.remove(2);
-    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, comment("test"));
   }
 
   @Test
@@ -136,7 +136,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void replaceCommentWithAnotherCorrectToIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, comment("test"));
     container.sourceTokens.set(3, Tokens.RP);
-    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, Tokens.RP);
   }
 
   @Test
@@ -150,7 +150,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void replaceCommentWithAnotherIncorrectToIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
     container.sourceTokens.set(4, Tokens.FACTORIAL);
-    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, Tokens.FACTORIAL);
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, Tokens.RP, Tokens.FACTORIAL);
   }
 
   @Test
@@ -164,7 +164,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void replaceWithCommentCorrectToIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP);
     container.sourceTokens.set(2, comment("test"));
-    assertTokens(new IdentifierToken("x"), Tokens.LP, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, comment("test"));
   }
 
   @Test
@@ -178,7 +178,7 @@ public class SimpleHybridEditorExternalTokensChangeTest extends BaseHybridEditor
   public void replaceWithCommentIncorrectToIncorrect() {
     setTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, Tokens.FACTORIAL);
     container.sourceTokens.set(4, comment("test"));
-    assertTokens(new IdentifierToken("x"), Tokens.LP, Tokens.RP, Tokens.RP, comment("test"));
+    assertTokens(new IdentifierToken("x"), Tokens.LP_CALL, Tokens.RP, Tokens.RP, comment("test"));
   }
 
   private void assertTokens(Token... tokens) {


### PR DESCRIPTION
When edit expression so that it becomes unparseable, spaces are added, and when it's parseable again, they are removed