### PR TITLE
Completion and tokens postprocessing improvements

### DIFF
--- a/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionSupport.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/completion/CompletionSupport.java
@@ -26,7 +26,9 @@ import jetbrains.jetpad.cell.text.TextEditing;
 import jetbrains.jetpad.cell.text.TextEditingTrait;
 import jetbrains.jetpad.cell.trait.CellTrait;
 import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
+import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.completion.*;
+import jetbrains.jetpad.event.Event;
 import jetbrains.jetpad.event.Key;
 import jetbrains.jetpad.event.KeyEvent;
 import jetbrains.jetpad.event.ModifierKey;
@@ -133,6 +135,7 @@ public class CompletionSupport {
         if (event.is(Key.ENTER)) {
           completer.handle(selectedItem);
           event.consume();
+          cell.dispatch(new Event(), Cells.AFTER_COMPLETED);
           return;
         }
 

--- a/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/text/TextEditingTrait.java
@@ -135,6 +135,7 @@ public class TextEditingTrait extends TextNavigationTrait {
     String currentText = TextEditing.nonNullText(editor);
     if (prefixed.size() == 1 && !currentText.isEmpty() && canCompleteWithCtrlSpace(editor)) {
       prefixed.get(0).complete(prefixText).run();
+      cell.dispatch(new Event(), Cells.AFTER_COMPLETED);
       event.consume();
     } else if (handler.canActivate()) {
       handler.activate();

--- a/cell/src/main/java/jetbrains/jetpad/cell/util/Cells.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/util/Cells.java
@@ -31,6 +31,7 @@ import java.util.List;
 public class Cells {
   public static final CellTraitEventSpec<Event> BECAME_EMPTY = new CellTraitEventSpec<>("becameEmpty", false);
   public static final CellTraitEventSpec<Event> BECAME_INVALID = new CellTraitEventSpec<>("becameInvalid", false);
+  public static final CellTraitEventSpec<Event> AFTER_COMPLETED = new CellTraitEventSpec<>("afterCompleted", false);
 
   public static Cell getNonPopupAncestor(Cell c) {
     Cell current = c;

--- a/cell/src/main/java/jetbrains/jetpad/cell/util/Cells.java
+++ b/cell/src/main/java/jetbrains/jetpad/cell/util/Cells.java
@@ -31,6 +31,8 @@ import java.util.List;
 public class Cells {
   public static final CellTraitEventSpec<Event> BECAME_EMPTY = new CellTraitEventSpec<>("becameEmpty", false);
   public static final CellTraitEventSpec<Event> BECAME_INVALID = new CellTraitEventSpec<>("becameInvalid", false);
+
+  public static final CellTraitEventSpec<Event> AFTER_EDITED = new CellTraitEventSpec<>("afterEdited", false);
   public static final CellTraitEventSpec<Event> AFTER_COMPLETED = new CellTraitEventSpec<>("afterCompleted", false);
 
   public static Cell getNonPopupAncestor(Cell c) {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -570,6 +570,7 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
     myTokenListEditor.tokens.clear();
     myTokenListEditor.tokens.addAll(tokens);
     myTokenListEditor.updateToPrintedTokens();
+    myTokensEditPostProcessor.afterTokensEdit(tokens, mySource.get());
   }
 
   public ObservableList<Token> tokens() {
@@ -798,6 +799,9 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
   private static class EmptyTokensEditPostProcessor<SourceT> implements TokensEditPostProcessor<SourceT> {
     @Override
     public void afterTokensEdit(List<Token> tokens, SourceT value) {
+    }
+    @Override
+    public void afterTokenCompleted(List<Token> tokens, SourceT value) {
     }
   };
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/BaseHybridSynchronizer.java
@@ -570,7 +570,6 @@ public abstract class BaseHybridSynchronizer<SourceT, SpecT extends SimpleHybrid
     myTokenListEditor.tokens.clear();
     myTokenListEditor.tokens.addAll(tokens);
     myTokenListEditor.updateToPrintedTokens();
-    myTokensEditPostProcessor.afterTokensEdit(tokens, mySource.get());
   }
 
   public ObservableList<Token> tokens() {

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
@@ -19,6 +19,7 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
+import jetbrains.jetpad.base.Runnables;
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.completion.*;
 import jetbrains.jetpad.hybrid.parser.Token;
@@ -73,7 +74,9 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
             Mapper<?, ?> targetItemMapper =  mapper.getDescendantMapper(targetItem);
             BaseHybridSynchronizer<?, ?> sync = mySyncProvider.apply(targetItemMapper);
             sync.setTokens(Arrays.asList(tokens));
-            return sync.selectOnCreation(selectionIndex, LAST);
+            return targetItemMapper.isAttached()
+                ? sync.selectOnCreation(selectionIndex, LAST)
+                : Runnables.EMPTY;
           }
         };
 

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/HybridWrapperRoleCompletion.java
@@ -21,7 +21,10 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
 import jetbrains.jetpad.base.Runnables;
 import jetbrains.jetpad.cell.Cell;
+import jetbrains.jetpad.cell.trait.CellTraitEventSpec;
+import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.completion.*;
+import jetbrains.jetpad.event.Event;
 import jetbrains.jetpad.hybrid.parser.Token;
 import jetbrains.jetpad.mapper.Mapper;
 import jetbrains.jetpad.projectional.generic.Role;
@@ -63,7 +66,7 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
   public CompletionSupplier createRoleCompletion(final Mapper<?, ?> mapper, ContainerT contextNode, final Role<WrapperT> target) {
     return new CompletionSupplier() {
       @Override
-      public List<CompletionItem> get(CompletionParameters cp) {
+      public List<CompletionItem> get(final CompletionParameters cp) {
         List<CompletionItem> result = new ArrayList<>();
 
         final BaseCompleter completer = new BaseCompleter() {
@@ -74,6 +77,8 @@ public class HybridWrapperRoleCompletion<ContainerT, WrapperT, TargetT> implemen
             Mapper<?, ?> targetItemMapper =  mapper.getDescendantMapper(targetItem);
             BaseHybridSynchronizer<?, ?> sync = mySyncProvider.apply(targetItemMapper);
             sync.setTokens(Arrays.asList(tokens));
+            CellTraitEventSpec<Event> traitEvent = cp.isMenu() ? Cells.AFTER_COMPLETED : Cells.AFTER_EDITED;
+            sync.getTargetList().iterator().next().dispatch(new Event(), traitEvent);
             return targetItemMapper.isAttached()
                 ? sync.selectOnCreation(selectionIndex, LAST)
                 : Runnables.EMPTY;

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
@@ -17,6 +17,8 @@ package jetbrains.jetpad.hybrid;
 
 import jetbrains.jetpad.cell.Cell;
 import jetbrains.jetpad.cell.trait.CellTrait;
+import jetbrains.jetpad.cell.trait.CellTraitEventSpec;
+import jetbrains.jetpad.cell.util.Cells;
 import jetbrains.jetpad.event.*;
 
 class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
@@ -30,20 +32,20 @@ class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
 
   @Override
   public void onKeyTyped(Cell cell, KeyEvent event) {
-    myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+    afterTokensEdit();
   }
 
   @Override
   public void onKeyPressed(Cell cell, KeyEvent event) {
     if (isRemove(event)) {
-      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+      afterTokensEdit();
     }
   }
 
   @Override
   public void onKeyPressedLowPriority(Cell cell, KeyEvent event) {
     if (isRemove(event)) {
-      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+      afterTokensEdit();
     }
   }
 
@@ -52,7 +54,7 @@ class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
     if (event.getResult() != null
         && event.getResult().isSupported(ContentKinds.SINGLE_LINE_TEXT)
         && !TextContentHelper.getText(event.getResult()).isEmpty()) {
-      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+      afterTokensEdit();
     }
   }
 
@@ -60,11 +62,26 @@ class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
   public void onPaste(Cell cell, PasteEvent event) {
     if (event.getContent().isSupported(ContentKinds.SINGLE_LINE_TEXT)
         && !TextContentHelper.getText(event.getContent()).isEmpty()) {
-      myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+      afterTokensEdit();
+    }
+  }
+
+  @Override
+  public void onCellTraitEvent(Cell cell, CellTraitEventSpec<?> spec, Event event) {
+    if (spec == Cells.AFTER_COMPLETED) {
+      afterTokenCompleted();
     }
   }
 
   private boolean isRemove(KeyEvent event) {
     return event.getKey() == Key.BACKSPACE || event.getKey() == Key.DELETE;
+  }
+
+  private void afterTokensEdit() {
+    myPostProcessor.afterTokensEdit(mySync.tokens(), mySync.property().get());
+  }
+
+  private void afterTokenCompleted() {
+    myPostProcessor.afterTokenCompleted(mySync.tokens(), mySync.property().get());
   }
 }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokenTextEditPostProcessorTrait.java
@@ -68,7 +68,9 @@ class TokenTextEditPostProcessorTrait<SourceT> extends CellTrait {
 
   @Override
   public void onCellTraitEvent(Cell cell, CellTraitEventSpec<?> spec, Event event) {
-    if (spec == Cells.AFTER_COMPLETED) {
+    if (spec == Cells.AFTER_EDITED) {
+      afterTokensEdit();
+    } else if (spec == Cells.AFTER_COMPLETED) {
       afterTokenCompleted();
     }
   }

--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessor.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TokensEditPostProcessor.java
@@ -21,4 +21,5 @@ import java.util.List;
 
 public interface TokensEditPostProcessor<SourceT> {
   void afterTokensEdit(List<Token> tokens, SourceT value);
+  void afterTokenCompleted(List<Token> tokens, SourceT value);
 }

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -18,6 +18,7 @@ package jetbrains.jetpad.hybrid;
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import jetbrains.jetpad.base.Registration;
 import jetbrains.jetpad.base.Runnables;
@@ -87,6 +88,7 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   public void dispose() {
     mapper.detachRoot();
     registration.remove();
+    myCellContainer.root.children().remove(targetCell);
   }
 
   @Test
@@ -1097,14 +1099,8 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
 
   @Test
   public void bulkCompletionInHybridWrapperRole() {
-    CompletionParameters requireBulkCompletion = new BaseCompletionParameters() {
-      @Override
-      public boolean isBulkCompletionRequired() {
-        return true;
-      }
-    };
     CompletionSupplier roleCompletionSupplier = createHybridWrapperRoleCompletionSupplier();
-    CompletionItems completionItems = new CompletionItems(roleCompletionSupplier.get(requireBulkCompletion));
+    CompletionItems completionItems = new CompletionItems(roleCompletionSupplier.get(requireBulkCompletion()));
 
     String code = "'text 1' + 1";
     for (boolean eagerCompletion : new boolean[] { false, true }) {
@@ -1113,6 +1109,15 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     completionItems.completeFirstMatch(code);
     assertTokensEqual(of(singleQtd("text 1"), Tokens.PLUS, integer(1)), sync.tokens());
     assertFocused(targetCell.lastChild());
+  }
+
+  private CompletionParameters requireBulkCompletion() {
+    return new BaseCompletionParameters() {
+      @Override
+      public boolean isBulkCompletionRequired() {
+        return true;
+      }
+    };
   }
 
   @Test
@@ -1253,6 +1258,13 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   @Test
   public void reinitInTokensPostProcessor() {
     Synchronizer initialSync = sync;
+    installResettingPostProcessor();
+    type("1 2"); type("3");
+    assertNotEquals(initialSync, sync);
+    assertTokens(integer(3));
+  }
+
+  private void installResettingPostProcessor() {
     sync.setTokensEditPostProcessor(new TokensEditPostProcessor<Expr>() {
       @Override
       public void afterTokensEdit(List<Token> tokens, Expr value) {
@@ -1261,10 +1273,11 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
           init();
         }
       }
+      @Override
+      public void afterTokenCompleted(List<Token> tokens, Expr value) {
+        throw new IllegalStateException();
+      }
     });
-    type("1 2"); type("3");
-    assertNotEquals(initialSync, sync);
-    assertTokens(integer(3));
   }
 
   @Test
@@ -1389,11 +1402,57 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
     assertTrue(lastSeenTokens.get().isEmpty());
   }
 
+  @Test
+  public void postProcessCompletion() {
+    // "value" prefix won't complete, tokens will stay [] multiple times
+    Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(false);
+    type("valu");
+    complete();
+    assertTokensEqual(ImmutableList.of(value()), lastSeenTokens.get());
+  }
+
+  @Test
+  public void postProcessCompletionWithMenu() {
+    Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(true);
+    complete();
+    enter();
+    assertTokensEqual(of(Tokens.FACTORIAL), lastSeenTokens.get());
+  }
+
+  @Test
+  public void postProcessTokensSet() {
+    Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(true);
+    setTokens(integer(1), integer(2));
+    assertTokensEqual(of(integer(1), integer(2)), lastSeenTokens.get());
+  }
+
+  @Test
+  public void postProcessHybridRoleCompletion() {
+    CompletionSupplier roleCompletionSupplier = createHybridWrapperRoleCompletionSupplier();
+    CompletionItems completionItems = new CompletionItems(roleCompletionSupplier.get(requireBulkCompletion()));
+
+    BaseHybridSynchronizer initialSync = sync;
+    installResettingPostProcessor();
+    completionItems.completeFirstMatch("1 2");
+
+    assertNotEquals(initialSync, sync);
+    assertTrue(sync.tokens().isEmpty());
+  }
+
   private Value<List<Token>> installTrackingPostProcessor(final boolean assertTokensChange) {
     final Value<List<Token>> lastSeenTokens = new Value<List<Token>>(Collections.EMPTY_LIST);
     sync.setTokensEditPostProcessor(new TokensEditPostProcessor<Expr>() {
       @Override
       public void afterTokensEdit(List<Token> tokens, Expr value) {
+        postProcess(tokens);
+      }
+
+      @Override
+      public void afterTokenCompleted(List<Token> tokens, Expr value) {
+        postProcess(tokens);
+      }
+
+      private void postProcess(List<Token> tokens) {
         if (assertTokensChange) {
           assertNotEquals(lastSeenTokens.get(), tokens);
         }

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -699,6 +699,10 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
             });
           }
 
+          if (spec == TextEditing.EAGER_COMPLETION) {
+            return true;
+          }
+
           return super.get(cell, spec);
         }
       });

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -478,6 +478,7 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
     type("ite");
 
     complete();
+    enter();
 
     assertEquals(1, container.children.size());
     assertTrue(container.children.get(0) instanceof NonEmptyChild);
@@ -1272,6 +1273,12 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
           public List<CompletionItem> get(CompletionParameters cp) {
             List<CompletionItem> result = new ArrayList<>();
             result.add(new SimpleCompletionItem("item") {
+              @Override
+              public Runnable complete(String text) {
+                return target.set(new NonEmptyChild());
+              }
+            });
+            result.add(new SimpleCompletionItem("item_alias") {
               @Override
               public Runnable complete(String text) {
                 return target.set(new NonEmptyChild());


### PR DESCRIPTION
Synchronous with https://github.com/JetBrains/datapad/pull/28, please merge both or neither.

This request contains prerequisites for dependent (main) one. It contains of the following changesets:
* `BaseProjectionalSynchronizer` and `ProjectionalListSynchronizerTest`: enable eager completion in projectional editor;
* `HybridWrapperRoleCompletion`: take into consideration that setting tokens may cause model detach;
* The rest: handle force (Ctrl+Space) completion — single automatic item (`TextEditingTrait`) or from menu (`CompletionSupport`).