### PR TITLE
DP-1230 Configurable eager completion

### DIFF
--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -80,7 +80,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   private List<Cell> myTargetList;
   private List<Registration> myRegistrations;
   private Character mySeparatorChar;
-  private boolean myEagerCompletion;
+  private boolean myEagerCompletion = false;
 
   private Property<SourceItemT> myForDeletion = new ValueProperty<>();
 

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/BaseProjectionalSynchronizer.java
@@ -80,6 +80,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   private List<Cell> myTargetList;
   private List<Registration> myRegistrations;
   private Character mySeparatorChar;
+  private boolean myEagerCompletion;
 
   private Property<SourceItemT> myForDeletion = new ValueProperty<>();
 
@@ -307,6 +308,11 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
   @Override
   public void setSeparator(Character ch) {
     mySeparatorChar = ch;
+  }
+
+  @Override
+  public void setEagerCompletion(boolean eagerCompletion) {
+    myEagerCompletion = eagerCompletion;
   }
 
   Character getSeparator() {
@@ -700,7 +706,7 @@ abstract class BaseProjectionalSynchronizer<SourceT, ContextT, SourceItemT> impl
           }
 
           if (spec == TextEditing.EAGER_COMPLETION) {
-            return true;
+            return myEagerCompletion;
           }
 
           return super.get(cell, spec);

--- a/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
+++ b/projectional/src/main/java/jetbrains/jetpad/projectional/cell/ProjectionalRoleSynchronizer.java
@@ -48,6 +48,7 @@ public interface ProjectionalRoleSynchronizer<ContextT, SourceT> extends RoleSyn
   void disablePlaceholder();
   void setItemFactory(Supplier<SourceT> itemFactory);
   void setSeparator(Character ch);
+  void setEagerCompletion(boolean eagerCompletion);
 
   SourceT getFocusedItem();
 

--- a/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
+++ b/projectional/src/test/java/jetbrains/jetpad/projectional/cell/ProjectionalListSynchronizerTest.java
@@ -157,7 +157,15 @@ public class ProjectionalListSynchronizerTest extends EditingTestCase {
   }
 
   @Test
-  public void insertWithCompletion() {
+  public void notInsertedWithNonEagerCompletion() {
+    type("item");
+    complete();
+    assertTrue(container.children.isEmpty());
+  }
+
+  @Test
+  public void insertWithEagerCompletion() {
+    rootMapper.mySynchronizer.setEagerCompletion(true);
     type("item");
     complete();
     assertNonEmpty(0);


### PR DESCRIPTION
NB: this is synchronous with https://github.com/JetBrains/datapad/pull/32, please merge both or neither.

Always eager completion fails a test from jetpad-experimental which I missed. This request makes eager/non-eager completion a subject of configuration so that old (non-eager) behavior is the default.