### PR TITLE
DP-1235 Fixed token cell text edit postprocessing

### DIFF
--- a/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
+++ b/hybrid/src/main/java/jetbrains/jetpad/hybrid/TextTokenCell.java
@@ -21,6 +21,7 @@ import jetbrains.jetpad.cell.TextCell;
 import jetbrains.jetpad.cell.text.TextEditing;
 import jetbrains.jetpad.cell.trait.CellTrait;
 import jetbrains.jetpad.cell.trait.CellTraitPropertySpec;
+import jetbrains.jetpad.cell.trait.CompositeCellTrait;
 import jetbrains.jetpad.cell.util.CellLists;
 import jetbrains.jetpad.hybrid.parser.SimpleToken;
 import jetbrains.jetpad.hybrid.parser.Token;
@@ -44,7 +45,13 @@ class TextTokenCell extends TextCell {
     bold().set(token instanceof SimpleToken && ((SimpleToken) token).isBold());
     text().set(token.text());
 
-    addTrait(createTrait());
+    addTrait(new CompositeCellTrait() {
+      @Override
+      protected CellTrait[] getBaseTraits(Cell cell) {
+        return new CellTrait[] { createTrait(), myPostProcessorTrait };
+      }
+    });
+
     updateFocusability();
   }
 
@@ -80,8 +87,7 @@ class TextTokenCell extends TextCell {
         return new CellTrait[] {
             new TokenCellTraits.LeftLeafTokenCellTrait(),
             new TokenCellTraits.RightLeafTokenCellTrait(),
-            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false),
-            myPostProcessorTrait
+            TextEditing.validTextEditing(myToken.getValidator(), tokenTextColor(), false)
         };
       }
 

--- a/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
+++ b/hybrid/src/test/java/jetbrains/jetpad/hybrid/BaseHybridEditorEditingTest.java
@@ -1320,6 +1320,17 @@ abstract class BaseHybridEditorEditingTest<ContainerT, MapperT extends Mapper<Co
   }
 
   @Test
+  public void postProcessTokensMerge() {
+    // Backspace is post-processed first for token, then for tokens list.
+    // First time no changes visible, don't verify.
+    Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(false);
+    type("1 2");
+    left();
+    backspace();
+    assertTokensEqual(of(integer(12)), lastSeenTokens.get());
+  }
+
+  @Test
   public void noPostProcessingOnNavigationAndSelection() {
     Value<List<Token>> lastSeenTokens = installTrackingPostProcessor(true);
     type("1 2");


### PR DESCRIPTION
The problem in previous implementation was that `TokenCellTrait`, though being composite, overrode some methods so that token text editing postprocessor didn't get called. This implementation defines a composite trait of higher-level, so that postprocessor is guaranteed to be called.